### PR TITLE
Fix default branch

### DIFF
--- a/.github/workflows/docker-push-ecr.yaml
+++ b/.github/workflows/docker-push-ecr.yaml
@@ -51,7 +51,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Build, tag, and push docker image to Amazon ECR
+      - name: Tag and push docker image to Amazon ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name }}

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -184,7 +184,7 @@ jobs:
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
 
       - name: Terraform Apply
-        if: ((github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && github.event_name == 'push' && steps.plan.outputs.exitcode == '2') || inputs.tf_deploy_override == true # https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
+        if: (github.event.ref_name == github.event.repository.default_branch && github.event_name == 'push' && steps.plan.outputs.exitcode == '2') || inputs.tf_deploy_override == true # https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
         run: terraform apply -auto-approve -input=false "tfplan"
 
       - uses: actions/github-script@0.9.0

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -184,7 +184,7 @@ jobs:
           echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
 
       - name: Terraform Apply
-        if: (github.event.ref_name == github.event.repository.default_branch && github.event_name == 'push' && steps.plan.outputs.exitcode == '2') || inputs.tf_deploy_override == true # https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
+        if: (github.ref_name == github.event.repository.default_branch && github.event_name == 'push' && steps.plan.outputs.exitcode == '2') || inputs.tf_deploy_override == true # https://developer.hashicorp.com/terraform/cli/commands/plan#detailed-exitcode
         run: terraform apply -auto-approve -input=false "tfplan"
 
       - uses: actions/github-script@0.9.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,8 @@ repos:
     rev: v1.77.0
     hooks:
       - id: terraform_fmt
+        args:
+          - --args=-recursive
       - id: terraform_validate
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
The current state is not working.

I found that the default branch is passed in the github.event 

https://github.com/swibrow/actions-playground/pull/2

and the event context is always in push events. 

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context