### PR TITLE
feat: add docker-build-push-ecr workflow

### DIFF
--- a/.github/workflows/_test-workflows.yaml
+++ b/.github/workflows/_test-workflows.yaml
@@ -43,6 +43,16 @@ jobs:
       docker_context: tests/docker
       docker_push: false
 
+  test_docker_build_push_ecr_no_image_tag:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      docker_context: tests/docker
+      docker_push: false
+
     # Enable once we have access to dai sandbox account
     # test_docker_push_ecr:
     # uses: ./.github/workflows/docker-push-ecr.yaml

--- a/.github/workflows/_test-workflows.yaml
+++ b/.github/workflows/_test-workflows.yaml
@@ -32,6 +32,17 @@ jobs:
       docker_context: tests/docker
       artifact_retention_days: 1
 
+  test_docker_build_push_ecr:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      image_tag: ${{ github.head_ref }}
+      docker_context: tests/docker
+      docker_push: false
+
     # Enable once we have access to dai sandbox account
     # test_docker_push_ecr:
     # uses: ./.github/workflows/docker-push-ecr.yaml

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -74,5 +74,5 @@ jobs:
           push: ${{ inputs.docker_push }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ github.sha }}
-            ${{ github.ref_name == github.event.repository.default_branch && format('{0}/{1}:latest', env.REGISTRY, env.REPOSITORY) }}
-            ${{ inputs.image_tag != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, inputs.image_tag) }}
+            ${{ (github.ref_name == github.event.repository.default_branch && format('{0}/{1}:latest', env.REGISTRY, env.REPOSITORY)) || '' }}
+            ${{ (inputs.image_tag != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, inputs.image_tag)) || '' }}

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ inputs.image_name }}
-          BRANCH: ${{ github.head_ref }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
         with:
           context: ${{ inputs.docker_context }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
@@ -75,4 +75,4 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ github.sha }}
             ${{ (github.ref_name == github.event.repository.default_branch && format('{0}/{1}:latest', env.REGISTRY, env.REPOSITORY)) || '' }}
-            ${{ (inputs.image_tag != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, inputs.image_tag)) || '' }}
+            ${{ (env.IMAGE_TAG != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, env.IMAGE_TAG)) || '' }}

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -74,6 +74,6 @@ jobs:
           cache-to: type=gha,mode=max
           push: ${{ inputs.docker_push }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ github.sha }}
+            ${{ github.ref_name == github.event.repository.default_branch && format('{0}/{1}:latest', env.REGISTRY, env.REPOSITORY) }}
             ${{ inputs.image_tag != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, inputs.image_tag) }}

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -1,4 +1,3 @@
-# The reason why I created this workflow is that without using artifacts, it's much faster.
 name: Docker
 
 on:

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -1,0 +1,79 @@
+# The reason why I created this workflow is that without using artifacts, it's much faster.
+name: Docker
+
+on:
+  workflow_call:
+    inputs:
+      aws_account_id:
+        description: "AWS Account ID"
+        type: string
+        required: true
+      aws_region:
+        description: "AWS Region"
+        type: string
+        required: true
+      aws_role_name:
+        description: "AWS Role Name"
+        type: string
+        required: true
+      image_name:
+        description: "Name of the Docker image to build"
+        type: string
+        required: false
+        default: ${{ github.event.repository.name }}
+      image_tag:
+        description: "Tag of the Docker image to build"
+        type: string
+        required: false
+      docker_context:
+        description: "Path to the build context"
+        type: string
+        required: false
+        default: .
+      docker_push:
+        description: "Push Image to ECR"
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_role_name }}
+          aws-region: ${{ inputs.aws_region }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and export
+        uses: docker/build-push-action@v5
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.image_name }}
+          BRANCH: ${{ github.head_ref }}
+        with:
+          context: ${{ inputs.docker_context }}
+          # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ inputs.docker_push }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:latest
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ github.sha }}
+            ${{ inputs.image_tag != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, inputs.image_tag) }}


### PR DESCRIPTION
It's faster than using build and push separately because upload/download artifact actions are not always a needed overhead