### PR TITLE
fix: terraform init arguments

### DIFF
--- a/.github/workflows/_test-workflows.yaml
+++ b/.github/workflows/_test-workflows.yaml
@@ -4,97 +4,51 @@ name: Test Reusable Workflows
 on:
   pull_request:
     branches:
-      - fix-tf-init
+      - main
 
 jobs:
   # Enable once we have access to dai sandbox account
-  test_terraform_deploy_basic_1:
+  test_terraform_deploy_basic:
     uses: ./.github/workflows/tf-deploy-basic.yaml
     with:
-      # github_artifact_path: path/to/artifacts
-      aws_account_id: 911453050078
-      aws_region: eu-west-1
-      # aws_role_name: ${{ vars.aws_role_name }}
+      github_artifact_path: path/to/artifacts
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
       environment: sandbox
       github_feedback: true
-      tf_deploy_override: false
+      tf_deploy_override: true
       tf_dir: tests/terraform
       tf_vars: var1=value1,var2=value2
       tf_version: 1.6.6
 
-  test_terraform_deploy_basic_2:
-    uses: ./.github/workflows/tf-deploy-basic.yaml
+  test_docker_build:
+    uses: ./.github/workflows/docker-build.yaml
     with:
-      # github_artifact_path: path/to/artifacts
-      aws_account_id: 911453050078
-      aws_region: eu-west-1
-      # aws_role_name: ${{ vars.aws_role_name }}
-      environment: sandbox
-      github_feedback: true
-      tf_state_bucket: tf-state-911453050078
-      tf_deploy_override: false
-      tf_dir: tests/terraform
-      tf_vars: var1=value1,var2=value2
-      tf_version: 1.6.6
+      image_name: test-docker-build
+      docker_context: tests/docker
+      artifact_retention_days: 1
 
-  test_terraform_deploy_basic_3:
-    uses: ./.github/workflows/tf-deploy-basic.yaml
+  test_docker_build_push_ecr:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
     with:
-      # github_artifact_path: path/to/artifacts
-      aws_account_id: 911453050078
-      aws_region: eu-west-1
-      # aws_role_name: ${{ vars.aws_role_name }}
-      environment: sandbox
-      tf_state_key: this-is-a-test
-      github_feedback: true
-      tf_deploy_override: false
-      tf_dir: tests/terraform
-      tf_vars: var1=value1,var2=value2
-      tf_version: 1.6.6
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      image_tag: ${{ github.head_ref }}
+      docker_context: tests/docker
+      docker_push: false
 
-  test_terraform_deploy_basic_4:
-    uses: ./.github/workflows/tf-deploy-basic.yaml
+  test_docker_build_push_ecr_no_image_tag:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
     with:
-      # github_artifact_path: path/to/artifacts
-      aws_account_id: 911453050078
-      aws_region: eu-west-1
-      # aws_role_name: ${{ vars.aws_role_name }}
-      environment: sandbox
-      tf_state_bucket: tf-state-911453050078
-      tf_state_key: this-is-a-test
-      github_feedback: true
-      tf_deploy_override: false
-      tf_dir: tests/terraform
-      tf_vars: var1=value1,var2=value2
-      tf_version: 1.6.6
-
-  # test_docker_build:
-  #   uses: ./.github/workflows/docker-build.yaml
-  #   with:
-  #     image_name: test-docker-build
-  #     docker_context: tests/docker
-  #     artifact_retention_days: 1
-
-  # test_docker_build_push_ecr:
-  #   uses: ./.github/workflows/docker-build-push-ecr.yaml
-  #   with:
-  #     aws_account_id: ${{ vars.aws_account_id }}
-  #     aws_region: ${{ vars.aws_region }}
-  #     aws_role_name: ${{ vars.aws_role_name }}
-  #     image_name: test-docker-build-push
-  #     image_tag: ${{ github.head_ref }}
-  #     docker_context: tests/docker
-  #     docker_push: false
-
-  # test_docker_build_push_ecr_no_image_tag:
-  #   uses: ./.github/workflows/docker-build-push-ecr.yaml
-  #   with:
-  #     aws_account_id: ${{ vars.aws_account_id }}
-  #     aws_region: ${{ vars.aws_region }}
-  #     aws_role_name: ${{ vars.aws_role_name }}
-  #     image_name: test-docker-build-push
-  #     docker_context: tests/docker
-  #     docker_push: false
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      docker_context: tests/docker
+      docker_push: false
 
     # Enable once we have access to dai sandbox account
     # test_docker_push_ecr:

--- a/.github/workflows/_test-workflows.yaml
+++ b/.github/workflows/_test-workflows.yaml
@@ -1,54 +1,100 @@
-# TODO: Setup access to dai sanbox account
+# TODO: Setup access to dai sandbox account
 name: Test Reusable Workflows
 
 on:
   pull_request:
     branches:
-      - main
+      - fix-tf-init
 
 jobs:
   # Enable once we have access to dai sandbox account
-  test_terraform_deploy_basic:
+  test_terraform_deploy_basic_1:
     uses: ./.github/workflows/tf-deploy-basic.yaml
     with:
-      github_artifact_path: path/to/artifacts
-      aws_account_id: ${{ vars.aws_account_id }}
-      aws_region: ${{ vars.aws_region }}
-      aws_role_name: ${{ vars.aws_role_name }}
+      # github_artifact_path: path/to/artifacts
+      aws_account_id: 911453050078
+      aws_region: eu-west-1
+      # aws_role_name: ${{ vars.aws_role_name }}
       environment: sandbox
       github_feedback: true
-      tf_deploy_override: true
+      tf_deploy_override: false
       tf_dir: tests/terraform
       tf_vars: var1=value1,var2=value2
       tf_version: 1.6.6
 
-  test_docker_build:
-    uses: ./.github/workflows/docker-build.yaml
+  test_terraform_deploy_basic_2:
+    uses: ./.github/workflows/tf-deploy-basic.yaml
     with:
-      image_name: test-docker-build
-      docker_context: tests/docker
-      artifact_retention_days: 1
+      # github_artifact_path: path/to/artifacts
+      aws_account_id: 911453050078
+      aws_region: eu-west-1
+      # aws_role_name: ${{ vars.aws_role_name }}
+      environment: sandbox
+      github_feedback: true
+      tf_state_bucket: tf-state-911453050078
+      tf_deploy_override: false
+      tf_dir: tests/terraform
+      tf_vars: var1=value1,var2=value2
+      tf_version: 1.6.6
 
-  test_docker_build_push_ecr:
-    uses: ./.github/workflows/docker-build-push-ecr.yaml
+  test_terraform_deploy_basic_3:
+    uses: ./.github/workflows/tf-deploy-basic.yaml
     with:
-      aws_account_id: ${{ vars.aws_account_id }}
-      aws_region: ${{ vars.aws_region }}
-      aws_role_name: ${{ vars.aws_role_name }}
-      image_name: test-docker-build-push
-      image_tag: ${{ github.head_ref }}
-      docker_context: tests/docker
-      docker_push: false
+      # github_artifact_path: path/to/artifacts
+      aws_account_id: 911453050078
+      aws_region: eu-west-1
+      # aws_role_name: ${{ vars.aws_role_name }}
+      environment: sandbox
+      tf_state_key: this-is-a-test
+      github_feedback: true
+      tf_deploy_override: false
+      tf_dir: tests/terraform
+      tf_vars: var1=value1,var2=value2
+      tf_version: 1.6.6
 
-  test_docker_build_push_ecr_no_image_tag:
-    uses: ./.github/workflows/docker-build-push-ecr.yaml
+  test_terraform_deploy_basic_4:
+    uses: ./.github/workflows/tf-deploy-basic.yaml
     with:
-      aws_account_id: ${{ vars.aws_account_id }}
-      aws_region: ${{ vars.aws_region }}
-      aws_role_name: ${{ vars.aws_role_name }}
-      image_name: test-docker-build-push
-      docker_context: tests/docker
-      docker_push: false
+      # github_artifact_path: path/to/artifacts
+      aws_account_id: 911453050078
+      aws_region: eu-west-1
+      # aws_role_name: ${{ vars.aws_role_name }}
+      environment: sandbox
+      tf_state_bucket: tf-state-911453050078
+      tf_state_key: this-is-a-test
+      github_feedback: true
+      tf_deploy_override: false
+      tf_dir: tests/terraform
+      tf_vars: var1=value1,var2=value2
+      tf_version: 1.6.6
+
+  # test_docker_build:
+  #   uses: ./.github/workflows/docker-build.yaml
+  #   with:
+  #     image_name: test-docker-build
+  #     docker_context: tests/docker
+  #     artifact_retention_days: 1
+
+  # test_docker_build_push_ecr:
+  #   uses: ./.github/workflows/docker-build-push-ecr.yaml
+  #   with:
+  #     aws_account_id: ${{ vars.aws_account_id }}
+  #     aws_region: ${{ vars.aws_region }}
+  #     aws_role_name: ${{ vars.aws_role_name }}
+  #     image_name: test-docker-build-push
+  #     image_tag: ${{ github.head_ref }}
+  #     docker_context: tests/docker
+  #     docker_push: false
+
+  # test_docker_build_push_ecr_no_image_tag:
+  #   uses: ./.github/workflows/docker-build-push-ecr.yaml
+  #   with:
+  #     aws_account_id: ${{ vars.aws_account_id }}
+  #     aws_region: ${{ vars.aws_region }}
+  #     aws_role_name: ${{ vars.aws_role_name }}
+  #     image_name: test-docker-build-push
+  #     docker_context: tests/docker
+  #     docker_push: false
 
     # Enable once we have access to dai sandbox account
     # test_docker_push_ecr:

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -105,7 +105,7 @@ jobs:
             tf_args="$tf_args -backend-config=key='${{ inputs.tf_state_key}}'"
           fi
 
-          echo terraform init \
+          echo running terraform init \
            -input=false \
            ${tf_args}
 

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -105,6 +105,10 @@ jobs:
             tf_args="$tf_args -backend-config=key='${{ inputs.tf_state_key}}'"
           fi
 
+          echo terraform init \
+           -input=false \
+           ${tf_args}
+
           terraform init \
            -input=false \
            ${tf_args}

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -145,7 +145,7 @@ jobs:
           done
 
           tf_plan_exitcode=0
-          echo terraform plan \
+          terraform plan \
            -detailed-exitcode \
            -input=false \
            -lock=false \

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -98,11 +98,16 @@ jobs:
         id: init
         run: |
           tf_args=""
-          if [ "${{ inputs.tf_state_key }}" != "" ] && [ "${{ inputs.tf_state_bucket }}" != "" ]; then
-             tf_args='-backend-config=key=${{ inputs.tf_state_key }} -backend-config=bucket=${{ inputs.tf_state_bucket }}'
+          if [ "${{ inputs.tf_state_bucket }}" != "" ]; then
+            tf_args="$tf_args -backend-config=bucket='${{ inputs.tf_state_bucket }}'"
           fi
-          terraform init ${tf_args}
+          if [ "${{ inputs.tf_state_key }}" != "" ]; then
+            tf_args="$tf_args -backend-config=key='${{ inputs.tf_state_key}}'"
+          fi
 
+          terraform init \
+           -input=false \
+           ${tf_args}
       - name: Terraform Format
         id: fmt
         run: terraform fmt -recursive -check
@@ -140,7 +145,7 @@ jobs:
           done
 
           tf_plan_exitcode=0
-          terraform plan \
+          echo terraform plan \
            -detailed-exitcode \
            -input=false \
            -lock=false \

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -17,7 +17,7 @@ on:
       aws_role_name:
         description: "The name of the role to assume with OIDC"
         type: string
-        required: true
+        required: false
         default: cicd-iac
       environment:
         description: "The environment name"


### PR DESCRIPTION
- Fix the terraform init argument when tf_state_key and tf_state_bucket are not all specified
- Make terraform init fail instead of asking for missing parameters
- Make the "aws_role_name" optional
- Echo the terraform init command
- typo