### PR TITLE
replace tf init parameters 

### DIFF
--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -38,6 +38,14 @@ on:
         required: false
         type: boolean
         default: false
+      tf_state_bucket:
+        description: "Deprecated: The name of the S3 bucket to store the Terraform state"
+        required: false
+        type: string
+      tf_state_key:
+        description: "Deprecated: The name of the S3 key to store the Terraform state"
+        required: false
+        type: string
       tf_backend_configs:
         description: "Comma separated list of backend-configs to pass to the init command"
         required: false
@@ -100,6 +108,14 @@ jobs:
               tf_args+=" -backend-config=$var"
             fi
           done <<< "${{ inputs.tf_backend_configs }}"
+
+          # Still keep the old deprecated inputs
+          if [ "${{ inputs.tf_state_bucket }}" != "" ]; then
+            tf_args+=" -backend-config=bucket=${{ inputs.tf_state_bucket }}"
+          fi
+          if [ "${{ inputs.tf_state_key }}" != "" ]; then
+            tf_args+=" -backend-config=key=${{ inputs.tf_state_key}}"
+          fi
 
           echo running terraform init -input=false ${tf_args}
           terraform init -input=false ${tf_args}

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -95,10 +95,11 @@ jobs:
         run: |
           tf_args=''
 
-          read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           while read -r var; do
-            tf_args+=" -backend-config=$var"
-          done < "${{ inputs.tf_backend_configs }}"
+            if [ -n "$var" ]; then
+              tf_args+=" -backend-config=$var"
+            fi
+          done <<< "${{ inputs.tf_backend_configs }}"
 
           echo running terraform init -input=false ${tf_args}
           terraform init -input=false ${tf_args}

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -100,10 +100,6 @@ jobs:
             tf_args+=" -backend-config=$var"
           done
 
-          if [ "${{ inputs.tf_state_key }}" != "" ] && [ "${{ inputs.tf_state_bucket }}" != "" ]; then
-             tf_args='-backend-config=key=${{ inputs.tf_state_key }} -backend-config=bucket=${{ inputs.tf_state_bucket }}'
-          fi
-
           echo running terraform init -input=false ${tf_args}
           terraform init -input=false ${tf_args}
 

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -95,7 +95,8 @@ jobs:
         run: |
           tf_args=''
 
-          IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
+          // IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
+          read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           for var in "${ADDR[@]}"; do
             tf_args+=" -backend-config=$var"
           done

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -47,7 +47,7 @@ on:
         required: false
         type: string
       tf_backend_configs:
-        description: "Comma separated list of backend-configs to pass to the init command"
+        description: "Newline separated list of backend-configs to pass to the init command"
         required: false
         type: string
       tf_var_files:

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -95,7 +95,6 @@ jobs:
         run: |
           tf_args=''
 
-          # IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           for var in "${ADDR[@]}"; do
             tf_args+=" -backend-config=$var"

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -17,7 +17,7 @@ on:
       aws_role_name:
         description: "The name of the role to assume with OIDC"
         type: string
-        required: true
+        required: false
         default: cicd-iac
       environment:
         description: "The environment name"
@@ -38,12 +38,8 @@ on:
         required: false
         type: boolean
         default: false
-      tf_state_bucket:
-        description: "The name of the S3 bucket to store the Terraform state"
-        required: false
-        type: string
-      tf_state_key:
-        description: "The name of the S3 key to store the Terraform state"
+      tf_backend_configs:
+        description: "Comma separated list of backend-configs to pass to the init command"
         required: false
         type: string
       tf_var_files:
@@ -97,10 +93,18 @@ jobs:
       - name: Terraform Init
         id: init
         run: |
-          tf_args=""
+          tf_args=''
+
+          IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
+          for var in "${ADDR[@]}"; do
+            tf_args+=" -backend-config=$var"
+          done
+
           if [ "${{ inputs.tf_state_key }}" != "" ] && [ "${{ inputs.tf_state_bucket }}" != "" ]; then
              tf_args='-backend-config=key=${{ inputs.tf_state_key }} -backend-config=bucket=${{ inputs.tf_state_bucket }}'
           fi
+
+          echo running terraform init ${tf_args}
           terraform init ${tf_args}
 
       - name: Terraform Format

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -39,11 +39,11 @@ on:
         type: boolean
         default: false
       tf_state_bucket:
-        description: "Deprecated: The name of the S3 bucket to store the Terraform state"
+        description: "The name of the S3 bucket to store the Terraform state"
         required: false
         type: string
       tf_state_key:
-        description: "Deprecated: The name of the S3 key to store the Terraform state"
+        description: "The name of the S3 key to store the Terraform state"
         required: false
         type: string
       tf_backend_configs:
@@ -109,7 +109,7 @@ jobs:
             fi
           done <<< "${{ inputs.tf_backend_configs }}"
 
-          # Still keep the old deprecated inputs
+          # Overwrite with the tf_state_bucket and tf_state_key variables
           if [ "${{ inputs.tf_state_bucket }}" != "" ]; then
             tf_args+=" -backend-config=bucket=${{ inputs.tf_state_bucket }}"
           fi

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -88,7 +88,7 @@ jobs:
           aws-region: ${{ inputs.aws_region }}
 
       - uses: actions/download-artifact@v4
-        if: inputs.github_artifact_path != ''
+        if: inputs.github_artifact_path != ""
         with:
           path: ${{ inputs.github_artifact_path }}
 
@@ -101,7 +101,7 @@ jobs:
       - name: Terraform Init
         id: init
         run: |
-          tf_args=''
+          tf_args=""
 
           while read -r var; do
             if [ -n "$var" ]; then
@@ -144,14 +144,14 @@ jobs:
 
           echo "Current working directory: $(pwd)"
 
-          tf_args=''
+          tf_args=""
 
-          IFS=',' read -ra ADDR <<< "${{ inputs.tf_vars }}"
+          IFS="," read -ra ADDR <<< "${{ inputs.tf_vars }}"
           for var in "${ADDR[@]}"; do
             tf_args+=" -var $var"
           done
 
-          IFS=',' read -ra ADDR <<< "${{ inputs.tf_var_files }}"
+          IFS="," read -ra ADDR <<< "${{ inputs.tf_var_files }}"
           for var_file in "${ADDR[@]}"; do
             tf_args+=" -var-file=$var_file"
           done

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -96,9 +96,9 @@ jobs:
           tf_args=''
 
           read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
-          for var in "${ADDR[@]}"; do
+          while read -r var; do
             tf_args+=" -backend-config=$var"
-          done
+          done < "${{ inputs.tf_backend_configs }}"
 
           echo running terraform init -input=false ${tf_args}
           terraform init -input=false ${tf_args}

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           tf_args=''
 
-          // IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
+          # IFS=',' read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           read -ra ADDR <<< "${{ inputs.tf_backend_configs }}"
           for var in "${ADDR[@]}"; do
             tf_args+=" -backend-config=$var"

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -88,7 +88,7 @@ jobs:
           aws-region: ${{ inputs.aws_region }}
 
       - uses: actions/download-artifact@v4
-        if: inputs.github_artifact_path != ""
+        if: inputs.github_artifact_path != ''
         with:
           path: ${{ inputs.github_artifact_path }}
 

--- a/.github/workflows/tf-deploy-basic.yaml
+++ b/.github/workflows/tf-deploy-basic.yaml
@@ -104,8 +104,8 @@ jobs:
              tf_args='-backend-config=key=${{ inputs.tf_state_key }} -backend-config=bucket=${{ inputs.tf_state_bucket }}'
           fi
 
-          echo running terraform init ${tf_args}
-          terraform init ${tf_args}
+          echo running terraform init -input=false ${tf_args}
+          terraform init -input=false ${tf_args}
 
       - name: Terraform Format
         id: fmt


### PR DESCRIPTION
Use a more generic way to pass arguments to terraform init (`tf_backend_configs` input).
the current `tf_state_bucket` and `tf_state_key` inputs are still kept but to discuss if we want to support both way or not ?
