### PR TITLE
feat: add possibility to configure the Dockerfile path separately and support Docker secrets

### DIFF
--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -43,12 +43,11 @@ jobs:
     uses: ./.github/workflows/docker-build-push-ecr.yaml
     secrets:
       docker_secrets: |
-        SECRET_TOKEN="S€cReT1!"
+        SECRET_TOKEN=${{ secrets.TEST_SECRET_TOKEN }}
     with:
       aws_account_id: ${{ vars.aws_account_id }}
       aws_region: ${{ vars.aws_region }}
       aws_role_name: ${{ vars.aws_role_name }}
-      image_name: test-docker-build-push
       docker_context: tests/docker
       dockerfile_path: tests/docker/secrets.Dockerfile
       docker_push: false

--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -3,9 +3,9 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/_test-docker.yaml'
-      - '.github/workflows/docker-*.yaml'
-      - 'tests/docker/**'
+      - ".github/workflows/_test-docker.yaml"
+      - ".github/workflows/docker-*.yaml"
+      - "tests/docker/**"
   push:
     branches:
       - main
@@ -24,12 +24,16 @@ jobs:
 
   test_docker_build_push_ecr_no_image_tag:
     uses: ./.github/workflows/docker-build-push-ecr.yaml
+    secrets:
+      docker_secrets: |
+        SECRET_TOKEN="S€cReT1!"
     with:
       aws_account_id: ${{ vars.aws_account_id }}
       aws_region: ${{ vars.aws_region }}
       aws_role_name: ${{ vars.aws_role_name }}
       image_name: test-docker-build-push
       docker_context: tests/docker
+      dockerfile_path: tests/docker/secrets.Dockerfile
       docker_push: false
 
   test_docker_build:

--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -24,6 +24,23 @@ jobs:
 
   test_docker_build_push_ecr_no_image_tag:
     uses: ./.github/workflows/docker-build-push-ecr.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      image_name: test-docker-build-push
+      docker_context: tests/docker
+      docker_push: false
+
+  test_docker_build:
+    uses: ./.github/workflows/docker-build.yaml
+    with:
+      image_name: test-docker-build
+      docker_context: tests/docker
+      artifact_retention_days: 1
+
+  test_docker_build_secrets:
+    uses: ./.github/workflows/docker-build-push-ecr.yaml
     secrets:
       docker_secrets: |
         SECRET_TOKEN="S€cReT1!"
@@ -35,10 +52,3 @@ jobs:
       docker_context: tests/docker
       dockerfile_path: tests/docker/secrets.Dockerfile
       docker_push: false
-
-  test_docker_build:
-    uses: ./.github/workflows/docker-build.yaml
-    with:
-      image_name: test-docker-build
-      docker_context: tests/docker
-      artifact_retention_days: 1

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -84,5 +84,4 @@ jobs:
           push: ${{ inputs.docker_push }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}:${{ github.sha }}
-            ${{ (github.ref_name == github.event.repository.default_branch && format('{0}/{1}:latest', env.REGISTRY, env.REPOSITORY)) || '' }}
             ${{ (env.IMAGE_TAG != '' && format('{0}/{1}:{2}', env.REGISTRY, env.REPOSITORY, env.IMAGE_TAG)) || '' }}

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -35,7 +35,7 @@ on:
         type: string
         default: "."
       dockerfile_path:
-        description: "Path to the Dockerfile. If not defined, will default to ${{ docker_context }}/Dockerfile"
+        description: "Path to the Dockerfile. If not defined, will default to {docker_context}/Dockerfile"
         type: string
         required: false
       docker_push:

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -3,9 +3,8 @@ name: Docker Build and Push
 on:
   workflow_call:
     secrets:
-      # it can contain secrets
-      docker_build_args:
-        description: "Comma-delimited list of build args to pass to docker build"
+      docker_secrets:
+        description: "Comma-delimited list of secrets to pass to docker build"
         required: false
     inputs:
       environment:
@@ -78,7 +77,7 @@ jobs:
         with:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.dockerfile_path }}
-          build-args: ${{ secrets.docker_build_args }}
+          secrets: ${{ secrets.docker_secrets }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -2,6 +2,11 @@ name: Docker Build and Push
 
 on:
   workflow_call:
+    secrets:
+      # it can contain secrets
+      docker_build_args:
+        description: "Comma-delimited list of build args to pass to docker build"
+        required: false
     inputs:
       environment:
         description: "Environment to run the build in"
@@ -37,10 +42,6 @@ on:
         description: "Push Image to ECR"
         type: boolean
         default: true
-      docker_build_args:
-        description: "Comma-delimited list of build args to pass to docker build"
-        type: string
-        default: ""
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -77,7 +78,7 @@ jobs:
         with:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.dockerfile_path }}
-          build-args: ${{ inputs.docker_build_args }}
+          build-args: ${{ secrets.docker_build_args }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -37,6 +37,10 @@ on:
         description: "Push Image to ECR"
         type: boolean
         default: true
+      docker_build_args:
+        description: "Comma-delimited list of build args to pass to docker build"
+        type: string
+        default: ""
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -73,6 +77,7 @@ jobs:
         with:
           context: ${{ inputs.docker_context }}
           file: ${{ inputs.dockerfile_path }}
+          build-args: ${{ inputs.docker_build_args }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       docker_secrets:
-        description: "Comma-delimited list of secrets to pass to docker build"
+        description: "Comma-delimited list of Github secrets to pass to docker build workflow"
         required: false
     inputs:
       environment:

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -35,9 +35,9 @@ on:
         type: string
         default: "."
       dockerfile_path:
-        description: "Path to the Dockerfile"
+        description: "Path to the Dockerfile. If not defined, will default to ${{ docker_context }}/Dockerfile"
         type: string
-        default: "Dockerfile"
+        required: false
       docker_push:
         description: "Push Image to ECR"
         type: boolean

--- a/.github/workflows/docker-build-push-ecr.yaml
+++ b/.github/workflows/docker-build-push-ecr.yaml
@@ -28,7 +28,11 @@ on:
       docker_context:
         description: "Path to the build context"
         type: string
-        default: '.'
+        default: "."
+      dockerfile_path:
+        description: "Path to the Dockerfile"
+        type: string
+        default: "Dockerfile"
       docker_push:
         description: "Push Image to ECR"
         type: boolean
@@ -68,6 +72,7 @@ jobs:
           IMAGE_TAG: ${{ inputs.image_tag }}
         with:
           context: ${{ inputs.docker_context }}
+          file: ${{ inputs.dockerfile_path }}
           # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ jobs:
       my-input: my-value
 ```
 
+For more usage examples please look for the `_test-*` workflow definition in the [`.github/workflows/`](.github/workflows/) folder.
+
 ### dflook workflows
 
 [dflook](https://github.com/dflook/terraform-github-actions) actions are an externally maintained set of actions that are used in the workflows.

--- a/tests/docker/secrets.Dockerfile
+++ b/tests/docker/secrets.Dockerfile
@@ -2,9 +2,7 @@ FROM alpine
 
 WORKDIR /app
 
-RUN --mount=type=bind,target=. \
-    --mount=type=secret,id=SECRET_TOKEN
-
-RUN echo "Hello, world! This is a secret $(cat /var/run/secrets/SECRET_TOKEN)" > hello.txt
+RUN --mount=type=secret,id=SECRET_TOKEN \
+    cp /run/secrets/SECRET_TOKEN hello.txt
 
 CMD ["cat", "hello.txt"]

--- a/tests/docker/secrets.Dockerfile
+++ b/tests/docker/secrets.Dockerfile
@@ -2,8 +2,14 @@ FROM alpine
 
 WORKDIR /app
 
-# Must be stored as an environment variable named SECRET_TOKEN and passed via 'docker build --secret id=SECRET_TOKEN [...]'
+# Must be stored as an environment variable (e.g. SECRET_TOKEN)
+# Passed via 'docker build --secret id=SECRET_TOKEN [...]'
 RUN --mount=type=secret,id=SECRET_TOKEN \
     cp /run/secrets/SECRET_TOKEN hello.txt
+
+RUN cat hello.txt
+
+RUN --mount=type=secret,id=SECRET_TOKEN \
+    cat /run/secrets/SECRET_TOKEN
 
 CMD ["cat", "hello.txt"]

--- a/tests/docker/secrets.Dockerfile
+++ b/tests/docker/secrets.Dockerfile
@@ -2,6 +2,7 @@ FROM alpine
 
 WORKDIR /app
 
+# Must be stored as an environment variable named SECRET_TOKEN and passed via 'docker build --secret id=SECRET_TOKEN [...]'
 RUN --mount=type=secret,id=SECRET_TOKEN \
     cp /run/secrets/SECRET_TOKEN hello.txt
 

--- a/tests/docker/secrets.Dockerfile
+++ b/tests/docker/secrets.Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+WORKDIR /app
+
+RUN --mount=type=bind,target=. \
+    --mount=type=secret,id=SECRET_TOKEN
+
+RUN echo "Hello, world! This is a secret $(cat /var/run/secrets/SECRET_TOKEN)" > hello.txt
+
+CMD ["cat", "hello.txt"]


### PR DESCRIPTION
Enabling `docker_secrets` to be passed downstream allows for secrets to be used at build-time (e.g. to clone a private repo or to serve a token to a private NPM/Python registry)

Usage:

```yaml
  test_docker_build_secrets:
    uses: ./.github/workflows/docker-build-push-ecr.yaml
    secrets:
      docker_secrets: |
        SECRET_TOKEN="S€cReT1!"
    with:
      [...]
```
