### PR TITLE
fix: install aws cli for dflook apply jobs

### DIFF
--- a/.github/workflows/_test-tf-dflook.yaml
+++ b/.github/workflows/_test-tf-dflook.yaml
@@ -21,7 +21,7 @@ jobs:
     with:
       environment: sandbox
       tf_pre_run:
-        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
 
   test_tf_dflook_feature:
     uses: ./.github/workflows/tf-dflook-feature.yaml

--- a/.github/workflows/_test-tf-dflook.yaml
+++ b/.github/workflows/_test-tf-dflook.yaml
@@ -17,6 +17,7 @@ jobs:
       environment: sandbox
 
   test_tf_dflook_apply:
+    needs: test_tf_dflook_plan
     uses: ./.github/workflows/tf-dflook-apply.yaml
     with:
       environment: sandbox

--- a/.github/workflows/_test-tf-dflook.yaml
+++ b/.github/workflows/_test-tf-dflook.yaml
@@ -20,6 +20,8 @@ jobs:
     uses: ./.github/workflows/tf-dflook-apply.yaml
     with:
       environment: sandbox
+      tf_pre_run:
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
 
   test_tf_dflook_feature:
     uses: ./.github/workflows/tf-dflook-feature.yaml

--- a/.github/workflows/tf-dflook-apply.yaml
+++ b/.github/workflows/tf-dflook-apply.yaml
@@ -46,6 +46,7 @@ jobs:
       pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:

--- a/.github/workflows/tf-dflook-apply.yaml
+++ b/.github/workflows/tf-dflook-apply.yaml
@@ -35,6 +35,9 @@ on:
       tf_vars:
         description: "Variables to set for the Terraform plan. This should be valid Terraform syntax."
         type: string
+      tf_pre_run:
+        description: "Command to run before Terraform is executed."
+        type: string
 jobs:
   apply:
     permissions:
@@ -68,8 +71,13 @@ jobs:
       - name: Terraform Apply
         uses: dflook/terraform-apply@v1
         env:
-          TERRAFORM_PRE_RUN:
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           label: ${{ inputs.environment }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-apply.yaml
+++ b/.github/workflows/tf-dflook-apply.yaml
@@ -67,6 +67,9 @@ jobs:
 
       - name: Terraform Apply
         uses: dflook/terraform-apply@v1
+        env:
+          TERRAFORM_PRE_RUN:
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
         with:
           label: ${{ inputs.environment }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-cleanup.yaml
+++ b/.github/workflows/tf-dflook-cleanup.yaml
@@ -62,6 +62,9 @@ jobs:
 
       - name: terraform destroy
         uses: dflook/terraform-destroy-workspace@v1
+        env:
+          TERRAFORM_PRE_RUN:
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
         with:
           workspace: ${{ github.head_ref }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-cleanup.yaml
+++ b/.github/workflows/tf-dflook-cleanup.yaml
@@ -37,6 +37,7 @@ jobs:
       pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:

--- a/.github/workflows/tf-dflook-cleanup.yaml
+++ b/.github/workflows/tf-dflook-cleanup.yaml
@@ -29,6 +29,9 @@ on:
       tf_backend_config_file:
         description: "Terraform backend config file"
         type: string
+      tf_pre_run:
+        description: "Command to run before Terraform is executed."
+        type: string
 jobs:
   cleanup:
     permissions:
@@ -64,8 +67,13 @@ jobs:
       - name: terraform destroy
         uses: dflook/terraform-destroy-workspace@v1
         env:
-          TERRAFORM_PRE_RUN:
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           workspace: ${{ github.head_ref }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-feature.yaml
+++ b/.github/workflows/tf-dflook-feature.yaml
@@ -38,6 +38,7 @@ jobs:
       pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:

--- a/.github/workflows/tf-dflook-feature.yaml
+++ b/.github/workflows/tf-dflook-feature.yaml
@@ -71,6 +71,9 @@ jobs:
 
       - name: Deploy test infrastrucutre
         uses: dflook/terraform-apply@v1
+        env:
+          TERRAFORM_PRE_RUN:
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
         with:
           workspace: ${{ github.head_ref }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-feature.yaml
+++ b/.github/workflows/tf-dflook-feature.yaml
@@ -29,7 +29,9 @@ on:
       tf_vars:
         description: "New line separated list of terraform variables"
         type: string
-
+      tf_pre_run:
+        description: "Command to run before Terraform is executed."
+        type: string
 jobs:
   feature:
     permissions:
@@ -73,8 +75,13 @@ jobs:
       - name: Deploy test infrastrucutre
         uses: dflook/terraform-apply@v1
         env:
-          TERRAFORM_PRE_RUN:
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           workspace: ${{ github.head_ref }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-dflook-plan.yaml
+++ b/.github/workflows/tf-dflook-plan.yaml
@@ -41,6 +41,9 @@ on:
       tf_vars:
         description: "Variables to set for the Terraform plan. This should be valid Terraform syntax."
         type: string
+      tf_pre_run:
+        description: "Command to run before Terraform is executed."
+        type: string
 jobs:
   plan:
     permissions:
@@ -90,8 +93,13 @@ jobs:
         id: plan
         uses: dflook/terraform-plan@v1
         env:
-          TERRAFORM_PRE_RUN:
-            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           label: ${{ inputs.environment}}
           add_github_comment: ${{ inputs.github_comment }}

--- a/.github/workflows/tf-dflook-plan.yaml
+++ b/.github/workflows/tf-dflook-plan.yaml
@@ -88,6 +88,9 @@ jobs:
       - name: Terraform Plan
         id: plan
         uses: dflook/terraform-plan@v1
+        env:
+          TERRAFORM_PRE_RUN:
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
         with:
           label: ${{ inputs.environment}}
           add_github_comment: ${{ inputs.github_comment }}

--- a/.github/workflows/tf-dflook-plan.yaml
+++ b/.github/workflows/tf-dflook-plan.yaml
@@ -49,6 +49,7 @@ jobs:
       pull-requests: write
     concurrency:
       group: ${{ github.workflow }}-${{ inputs.environment }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:


### PR DESCRIPTION
Installs aws cli as an extra step for plan, apply and destroy jobs

```
Tue, 09 Apr 2024 15:13:34 GMT
Executing TERRAFORM_PRE_RUN
Tue, 09 Apr 2024 15:13:34 GMT
  Executing init commands specified in 'TERRAFORM_PRE_RUN' environment variable
Tue, 09 Apr 2024 15:13:35 GMT
  ::stop-commands::***
Tue, 09 Apr 2024 15:13:35 GMT
  + curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip
Tue, 09 Apr 2024 15:13:35 GMT
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
Tue, 09 Apr 2024 15:13:35 GMT
                                   Dload  Upload   Total   Spent    Left  Speed
Tue, 09 Apr 2024 15:13:35 GMT
  
Tue, 09 Apr 2024 15:13:35 GMT
    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
Tue, 09 Apr 2024 15:13:35 GMT
  100 57.6M  100 57.6M    0     0   124M      0 --:--:-- --:--:-- --:--:--  124M
Tue, 09 Apr 2024 15:13:35 GMT
  + unzip -qq awscliv2.zip
Tue, 09 Apr 2024 15:13:37 GMT
  + ./aws/install
Tue, 09 Apr 2024 15:13:38 GMT
  You can now run: /usr/local/bin/aws --version
Tue, 09 Apr 2024 15:13:38 GMT
  ::***::
  ```