### PR TITLE
[tf-cleanup]-allow-specify-tf-workspace

### DIFF
--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -31,6 +31,9 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+      tf_workspace:
+        description: "Terraform workspace"
+        type: string
 jobs:
   cleanup:
     permissions:
@@ -74,7 +77,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ github.head_ref }}
+          workspace: ${{ tf_workspace || github.head_ref }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}


### PR DESCRIPTION
The issue is that when we call this workflow on `workflow_dispatch` we do not have `github.head_ref` therefore I would like to add the possibility to inject the tf_workspace. 
Example:
https://github.com/tx-pts-dai/terraform-aws-kubernetes-platform/actions/runs/8880678914/job/24381276096

Should we add this also on other workflows to support all the workflow triggers?
For context, here is the doc for `github.head_ref`
```
github.head_ref	string	The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.
```