### PR TITLE
Allow to specify tf workspace

### DIFF
--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -53,6 +53,7 @@ jobs:
       TF_BACKEND_CONFIG_FILES: ${{ inputs.tf_backend_config_files || vars.tf_backend_config_files }}
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
+      TF_WORKSPACE: ${{ inputs.tf_workspace || vars.tf_workspace || github.head_ref}}
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
@@ -77,7 +78,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ inputs.tf_workspace || github.head_ref }}
+          workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -77,7 +77,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ tf_workspace || github.head_ref }}
+          workspace: ${{ inputs.tf_workspace || github.head_ref }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -31,6 +31,9 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+      tf_workspace:
+        description: "Terraform workspace"
+        type: string
 jobs:
   cleanup:
     permissions:
@@ -74,7 +77,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ github.head_ref }}
+          workspace: ${{ tf_workspace || github.head_ref }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -31,6 +31,9 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+      tf_workspace:
+          description: "Terraform workspace"
+          type: string
 jobs:
   feature:
     permissions:
@@ -66,7 +69,7 @@ jobs:
       - name: Use branch workspace
         uses: dflook/terraform-new-workspace@a7e66c5defccc8bdcfe4dd6b32b4064812049ed1 # v1
         with:
-          workspace: ${{ github.head_ref }}
+          workspace: ${{ inputs.tf_workspace || github.head_ref }}
           path: ${{ env.TF_DIR }}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
@@ -82,7 +85,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ github.head_ref }}
+          workspace: ${{ inputs.tf_workspace || github.head_ref }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -53,6 +53,7 @@ jobs:
       TF_BACKEND_CONFIG_FILES: ${{ inputs.tf_backend_config_files || vars.tf_backend_config_files }}
       TF_VAR_FILES: ${{ inputs.tf_var_files || vars.tf_var_files }}
       TF_VARS: ${{ inputs.tf_vars || vars.tf_vars }}
+      TF_WORKSPACE: ${{ inputs.tf_workspace || vars.tf_workspace || github.head_ref}}
     steps:
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
@@ -69,7 +70,7 @@ jobs:
       - name: Use branch workspace
         uses: dflook/terraform-new-workspace@a7e66c5defccc8bdcfe4dd6b32b4064812049ed1 # v1
         with:
-          workspace: ${{ inputs.tf_workspace || github.head_ref }}
+          workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR }}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
@@ -85,7 +86,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          workspace: ${{ inputs.tf_workspace || github.head_ref }}
+          workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}

--- a/docs/README-tf-deploy.md
+++ b/docs/README-tf-deploy.md
@@ -51,4 +51,3 @@ jobs:
     with:
       environment: sandbox
 ```
-


### PR DESCRIPTION
The issue is that when we call this workflow on workflow_dispatch we do not have `github.head_ref` therefore I would like to add the possibility to inject the `tf_workspace`.
Example:
https://github.com/tx-pts-dai/terraform-aws-kubernetes-platform/actions/runs/8880678914/job/24381276096

Should we add this also on other workflows to support all the workflow triggers?
For context, here is the doc for `github.head_ref`

> github.head_ref	string	
> The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.