### PR TITLE
Fum 3196 too big plan

### DIFF
--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -115,7 +115,7 @@ jobs:
         env:
           TERRAFORM_PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
         run: |
-          MAX_PLAN_LENGTH=150000
+          MAX_PLAN_LENGTH=120000
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           length=${#TERRAFORM_PLAN}         

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -119,7 +119,7 @@ jobs:
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           PLAN_LENGTH=${#TERRAFORM_PLAN}         
-          START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
+          START=$(PLAN_LENGTH - MAX_PLAN_LENGTH)
           if [ "$START" -lt 0 ]; then
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -125,7 +125,7 @@ jobs:
             SHORT_PLAN=${TERRAFORM_PLAN}
           else
             echo "Plan will be cut to max ${MAX_PLAN_LENGTH} chars ! (LENGTH: ${PLAN_LENGTH})"
-            SHORT_PLAN=${TERRAFORM_PLAN:start:MAX_PLAN_LENGTH}
+            SHORT_PLAN=${TERRAFORM_PLAN:START:MAX_PLAN_LENGTH}
           fi
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -124,7 +124,7 @@ jobs:
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}
           else
-            echo "Plan will be cut to max ${MAX_PLAN_LENGTH} chars ! (LENGTH: ${PLAN_LENGTH})"
+            echo ":warning: Plan output is too long to be displayed (${PLAN_LENGTH} chars). Only the last ${MAX_PLAN_LENGTH} characters will be printed. "
             SHORT_PLAN=${TERRAFORM_PLAN:START:MAX_PLAN_LENGTH}
           fi
           delimiter="$(openssl rand -hex 8)"

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -120,7 +120,7 @@ jobs:
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           PLAN_LENGTH=${#TERRAFORM_PLAN}         
           START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
-          if [ "$start" -lt 0 ]; then
+          if [ "$START" -lt 0 ]; then
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}
           else

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -118,13 +118,13 @@ jobs:
           MAX_PLAN_LENGTH=120000
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
-          length=${#TERRAFORM_PLAN}         
-          start=$((length - MAX_PLAN_LENGTH))
+          PLAN_LENGTH=${#TERRAFORM_PLAN}         
+          START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
           if [ "$start" -lt 0 ]; then
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}
           else
-            echo "Plan will be cut to max ${MAX_PLAN_LENGTH} chars ! (LENGTH: ${#TERRAFORM_PLAN})"
+            echo "Plan will be cut to max ${MAX_PLAN_LENGTH} chars ! (LENGTH: ${PLAN_LENGTH})"
             SHORT_PLAN=${TERRAFORM_PLAN:start:MAX_PLAN_LENGTH}
           fi
           delimiter="$(openssl rand -hex 8)"

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -132,11 +132,18 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
+          # echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
 
+      - name: test step
+        if: github.event_name == 'pull_request'
+        env:
+          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
+        run: |
+          echo "$SUMMARY" 
+          
       - name: Publish Terraform Plan to Task Summary
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -119,7 +119,7 @@ jobs:
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           PLAN_LENGTH=${#TERRAFORM_PLAN}         
-          START=$(PLAN_LENGTH - MAX_PLAN_LENGTH)
+          START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
           if [ "$START" -lt 0 ]; then
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -122,9 +122,10 @@ jobs:
           # Calculate the start position for the last 1000 characters
           start=$((length - 1000))
 
-          echo $start
-          echo $length
+          echo "$start"
+          echo "$length"
           SHORT_PLAN=${TERRAFORM_PLAN:start:100}
+          echo "$SHORT_PLAN"
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -117,15 +117,15 @@ jobs:
         run: |
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
-
           length=${#TERRAFORM_PLAN}         
-          # Calculate the start position for the last 1000 characters
           start=$((length - 100000))
-
-          echo "$start"
-          echo "$length"
-          SHORT_PLAN=${TERRAFORM_PLAN:start:100000}
-          echo "$SHORT_PLAN"
+          if [ "$start" -lt 0 ]; then
+            echo "Plan will not be cut !"
+            SHORT_PLAN=${TERRAFORM_PLAN}
+          else
+            echo "Plan will be cut to max 100000 chars ! (LENGTH: ${#TERRAFORM_PLAN})"
+            SHORT_PLAN=${TERRAFORM_PLAN:start:100000}
+          fi
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -115,7 +115,7 @@ jobs:
         env:
           TERRAFORM_PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
         run: |
-          MAX_PLAN_LENGTH=120000
+          MAX_PLAN_LENGTH=150000
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           length=${#TERRAFORM_PLAN}         

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -135,7 +135,7 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "${TERRAFORM_PLAN:start:1000}" >> $GITHUB_OUTPUT
+          echo "${TERRAFORM_PLAN:start:100}" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -124,7 +124,7 @@ jobs:
 
           echo "$start"
           echo "$length"
-          SHORT_PLAN=${TERRAFORM_PLAN:start:100}
+          SHORT_PLAN=${TERRAFORM_PLAN:start:10000}
           echo "$SHORT_PLAN"
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -121,21 +121,17 @@ jobs:
           length=${#TERRAFORM_PLAN}         
           # Calculate the start position for the last 1000 characters
           start=$((length - 1000))
-          
-          # Extract and print the last 1000 characters
-          if (( start > 0 )); then
-              echo "${TERRAFORM_PLAN:start:1000}"
-          else
-              echo "$TERRAFORM_PLAN"
-          fi
-          
+
+          echo $start
+          echo $length
+          SHORT_PLAN=${TERRAFORM_PLAN:start:100}
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "${TERRAFORM_PLAN:start:100}" >> $GITHUB_OUTPUT
+          echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -115,16 +115,17 @@ jobs:
         env:
           TERRAFORM_PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
         run: |
+          MAX_PLAN_LENGTH=120000
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
           length=${#TERRAFORM_PLAN}         
-          start=$((length - 100000))
+          start=$((length - MAX_PLAN_LENGTH))
           if [ "$start" -lt 0 ]; then
             echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}
           else
-            echo "Plan will be cut to max 100000 chars ! (LENGTH: ${#TERRAFORM_PLAN})"
-            SHORT_PLAN=${TERRAFORM_PLAN:start:100000}
+            echo "Plan will be cut to max ${MAX_PLAN_LENGTH} chars ! (LENGTH: ${#TERRAFORM_PLAN})"
+            SHORT_PLAN=${TERRAFORM_PLAN:start:MAX_PLAN_LENGTH}
           fi
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -118,8 +118,17 @@ jobs:
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
 
-          echo "plan length is ${#TERRAFORM_PLAN}"
-          tail -1000 "$TERRAFORM_PLAN"
+          length=${#TERRAFORM_PLAN}         
+          # Calculate the start position for the last 1000 characters
+          start=$((length - 1000))
+          
+          # Extract and print the last 1000 characters
+          if (( start > 0 )); then
+              echo "${file_content:start:1000}"
+          else
+              echo "$file_content"
+          fi
+          
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -118,6 +118,8 @@ jobs:
           TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
 
+          echo "plan length is ${#TERRAFORM_PLAN}"
+
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -132,7 +132,7 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          # echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
+          echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -124,7 +124,7 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+          # echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -124,9 +124,9 @@ jobs:
           
           # Extract and print the last 1000 characters
           if (( start > 0 )); then
-              echo "${file_content:start:1000}"
+              echo "${TERRAFORM_PLAN:start:1000}"
           else
-              echo "$file_content"
+              echo "$TERRAFORM_PLAN"
           fi
           
           delimiter="$(openssl rand -hex 8)"
@@ -135,7 +135,7 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          # echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+          echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -121,7 +121,6 @@ jobs:
           PLAN_LENGTH=${#TERRAFORM_PLAN}         
           START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
           if [ "$START" -lt 0 ]; then
-            echo "Plan will not be cut !"
             SHORT_PLAN=${TERRAFORM_PLAN}
           else
             echo ":warning: Plan output is too long to be displayed (${PLAN_LENGTH} chars). Only the last ${MAX_PLAN_LENGTH} characters will be printed. "

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -119,7 +119,7 @@ jobs:
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
 
           echo "plan length is ${#TERRAFORM_PLAN}"
-          echo ($TERRAFORM_PLAN | tail -10)
+          tail -1000 "$TERRAFORM_PLAN"
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -119,7 +119,7 @@ jobs:
           TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
 
           echo "plan length is ${#TERRAFORM_PLAN}"
-
+          echo ($TERRAFORM_PLAN | tail -10)
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
           echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -135,7 +135,7 @@ jobs:
           echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
           echo "" >> $GITHUB_OUTPUT
           echo '```terraform' >> $GITHUB_OUTPUT
-          echo "$TERRAFORM_PLAN" >> $GITHUB_OUTPUT
+          echo "${TERRAFORM_PLAN:start:1000}" >> $GITHUB_OUTPUT
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -136,7 +136,6 @@ jobs:
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
-          
       - name: Publish Terraform Plan to Task Summary
         if: github.event_name == 'pull_request'
         env:

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -120,11 +120,11 @@ jobs:
 
           length=${#TERRAFORM_PLAN}         
           # Calculate the start position for the last 1000 characters
-          start=$((length - 1000))
+          start=$((length - 100000))
 
           echo "$start"
           echo "$length"
-          SHORT_PLAN=${TERRAFORM_PLAN:start:10000}
+          SHORT_PLAN=${TERRAFORM_PLAN:start:100000}
           echo "$SHORT_PLAN"
           delimiter="$(openssl rand -hex 8)"
           echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
@@ -136,13 +136,6 @@ jobs:
           echo '```' >> $GITHUB_OUTPUT
           echo "</details>" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
-
-      - name: test step
-        if: github.event_name == 'pull_request'
-        env:
-          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
-        run: |
-          echo "$SUMMARY" 
           
       - name: Publish Terraform Plan to Task Summary
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This is quite a nasty error that has been reported for quite a long time on different github issues. The issue is that there is that the github runners variables such as GITHUB_STEP_SUMMARY has a max size of whatever shell/bash limitations. As example, the error 

`{{An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/fum-3137/fum-3137'. Argument list too long}}`

can be reproduced with any simple bash command such as tail, with a too long plan as an argument.

The solution I came up with was to trim the SUMMARY to max 120’000 chars (I think it’s about the right threshold). This way it also works for verrrrrry long plans. I tested with different values from 20’000 up to 100’000 it seems too low, for 150’000 it crashes as well with the same error, therefore I picked arbitrarily 120'000 chars which looks to be fine. The plan I tested on was about 180’000 chars long. This has fixed the issue as you can see here https://github.com/DND-IT/fum-3196/actions/runs/9268960731

Now we can still ask ourselves wether this is an useful step when the plan is too big, because you don't see everything in the output anyway so it's not fully accurate... Maybe we should just return something like "Your plan is too big, check the action" or so instead of cutting it ?  Anyway the logic will be the same