### PR TITLE
fix: Release wf crashing on renovates PRs

### DIFF
--- a/.github/workflows/gh-release-on-main.yaml
+++ b/.github/workflows/gh-release-on-main.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Retrieve Merge Commit Message
         id: merge_commit_message
         run: |
-          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B | head -n 1)
           echo "COMMIT_MESSAGE=$COMMIT_MESSAGE" >> $GITHUB_ENV
 
       - name: Determine version increment


### PR DESCRIPTION
Renovates PR crashing the WF because containing tables. Example:

```
chore(deps): update tx-pts-dai/github-workflows action to v0.37.0

| datasource  | package                     | from    | to      |
| ----------- | --------------------------- | ------- | ------- |
| github-tags | tx-pts-dai/github-workflows | v0.25.0 | v0.37.0 |

```
This then breaks the ENV vars due to pipe char. More in general it looks good to extract only the first line and avoid special characters. This is where the useful information is.