### PR TITLE
Move tf presteps

### DIFF
--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -77,6 +77,12 @@ jobs:
           role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Execute Terraform Pre Run
+        run: eval "${{ inputs.tf_pre_run }}"
+        env:
+          TERRAFORM_PRE_RUN: ${{ inputs.tf_pre_run || '' }}
+        if: env.TERRAFORM_PRE_RUN != ''
+
       - name: Download Artifacts
         env:
           GH_ARTIFACT_PATH: ${{ inputs.gh_artifact_path || vars.gh_artifact_path || '' }}
@@ -105,11 +111,7 @@ jobs:
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
-            if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
-            else
-              eval "${{ inputs.tf_pre_run }}"
-            fi
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
         with:
           label: ${{ inputs.environment}}
           add_github_comment: ${{ inputs.github_comment }}

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -78,10 +78,10 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Execute Terraform Pre Run
+        if: env.TERRAFORM_PRE_RUN != ''
         run: eval "${{ inputs.tf_pre_run }}"
         env:
           TERRAFORM_PRE_RUN: ${{ inputs.tf_pre_run || '' }}
-        if: env.TERRAFORM_PRE_RUN != ''
 
       - name: Download Artifacts
         env:
@@ -91,12 +91,12 @@ jobs:
         with:
           path: ${{ env.GH_ARTIFACT_PATH }}
 
-      # - name: Terraform Format
-      #   uses: dflook/terraform-fmt-check@86914e9afad7218471018af867cc8d157d485d4b # v1
-      #   with:
-      #     path: ${{ env.TF_DIR}}
-      #     backend_config: ${{ env.TF_BACKEND_CONFIGS }}
-      #     backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+      - name: Terraform Format
+        uses: dflook/terraform-fmt-check@86914e9afad7218471018af867cc8d157d485d4b # v1
+        with:
+          path: ${{ env.TF_DIR}}
+          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
       - name: Terraform Validate
         uses: dflook/terraform-validate@9cfdf207ffbd0ec5d171403a24feb222591ffdc7 # v1

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -91,12 +91,12 @@ jobs:
         with:
           path: ${{ env.GH_ARTIFACT_PATH }}
 
-      - name: Terraform Format
-        uses: dflook/terraform-fmt-check@86914e9afad7218471018af867cc8d157d485d4b # v1
-        with:
-          path: ${{ env.TF_DIR}}
-          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
-          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+      # - name: Terraform Format
+      #   uses: dflook/terraform-fmt-check@86914e9afad7218471018af867cc8d157d485d4b # v1
+      #   with:
+      #     path: ${{ env.TF_DIR}}
+      #     backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+      #     backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
       - name: Terraform Validate
         uses: dflook/terraform-validate@9cfdf207ffbd0ec5d171403a24feb222591ffdc7 # v1


### PR DESCRIPTION
Reason: I want the input tf_pre_steps to be executed before ANY terraform command. This means moving it before the terraform format check and the terraform validate. 
I did this only in the plan as we do not do additional tf steps in other workflows