### PR TITLE
fix: retry terraform workspace destroy workflow if the first try fails

### DIFF
--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -78,8 +78,30 @@ jobs:
           role-to-assume: ${{ env.ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: terraform destroy
+      - name: Terraform Destroy
         uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151 # v1
+        id: first_try
+        continue-on-error: true
+        env:
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
+        with:
+          workspace: ${{ env.TF_WORKSPACE }}
+          path: ${{ env.TF_DIR}}
+          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+          var_file: ${{ env.TF_VAR_FILES }}
+          variables: ${{ env.TF_VARS }}
+
+      - name: Retry Terraform Destroy
+        uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151 # v1
+        if: ${{ steps.first_try.outputs.failure-reason == 'destroy-failed' }}
+        continue-on-error: true
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
-      - name: Configure AWS credentials
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         env:
           ROLE_TO_ASSUME: ${{ inputs.aws_oidc_role_arn || vars.aws_oidc_role_arn || format('arn:aws:iam::{0}:role/{1}', inputs.aws_account_id, inputs.aws_role_name) }}
@@ -91,7 +91,7 @@ jobs:
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
-      - name: Deploy test infrastrucutre
+      - name: Deploy Test Infrastrucutre
         uses: dflook/terraform-apply@dcda97d729f1843ede471d2fac989cb946f5622a # v1
         env:
           TERRAFORM_PRE_RUN: |


### PR DESCRIPTION
Prevent dangling resources from feature branches. 

Sometimes terraform hangs on destroying some resources due to race conditions. retry normally works. 