### PR TITLE
fix: update destroy workflows to fail on second attempt

### DIFF
--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -101,15 +101,6 @@ jobs:
       - name: Retry Terraform Destroy
         uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151 # v1
         if: ${{ steps.first_try.outputs.failure-reason == 'destroy-failed' }}
-        continue-on-error: true
-        env:
-          TERRAFORM_PRE_RUN: |
-            AWS_CLI_VERSION=2.15.36
-            if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
-            else
-              eval "${{ inputs.tf_pre_run }}"
-            fi
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Terraform Destroy
         uses: dflook/terraform-destroy@65f689138f6e3549c0aa2fd92153fce0bead4ed7 # v1
+        id: first_try
+        continue-on-error: true
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
@@ -72,6 +74,15 @@ jobs:
             else
               eval "${{ inputs.tf_pre_run }}"
             fi
+        with:
+          path: ${{ env.TF_DIR}}
+          backend_config: ${{ env.TF_BACKEND_CONFIGS }}
+          backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
+          var_file: ${{ env.TF_VAR_FILES }}
+          variables: ${{ env.TF_VARS }}
+
+      - name: Terraform Destroy
+        uses: dflook/terraform-destroy@65f689138f6e3549c0aa2fd92153fce0bead4ed7 # v1
         with:
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}


### PR DESCRIPTION
Dont need to download aws cli again since its already in the workspace and mounted into the container. 

Also added the retry to the tf-destroy workflow