### PR TITLE
fix: add overwrite arg to awscli unzip

### DIFF
--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -85,7 +85,7 @@ jobs:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else
               eval "${{ inputs.tf_pre_run }}"
             fi

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -86,7 +86,7 @@ jobs:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else
               eval "${{ inputs.tf_pre_run }}"
             fi
@@ -101,6 +101,14 @@ jobs:
       - name: Retry Terraform Destroy
         uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151 # v1
         if: ${{ steps.first_try.outputs.failure-reason == 'destroy-failed' }}
+        env:
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           workspace: ${{ env.TF_WORKSPACE }}
           path: ${{ env.TF_DIR}}

--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -70,7 +70,7 @@ jobs:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else
               eval "${{ inputs.tf_pre_run }}"
             fi
@@ -83,6 +83,14 @@ jobs:
 
       - name: Terraform Destroy
         uses: dflook/terraform-destroy@65f689138f6e3549c0aa2fd92153fce0bead4ed7 # v1
+        env:
+          TERRAFORM_PRE_RUN: |
+            AWS_CLI_VERSION=2.15.36
+            if [ -z "${{ inputs.tf_pre_run }}" ]; then
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
+            else
+              eval "${{ inputs.tf_pre_run }}"
+            fi
         with:
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -83,7 +83,7 @@ jobs:
         with:
           path: ${{ env.GH_ARTIFACT_PATH }}
 
-      - name: Use branch workspace
+      - name: Use Branch Workspace
         uses: dflook/terraform-new-workspace@74ceae9c6f940846d7f498bb45c319421abf1041 # v1
         with:
           workspace: ${{ env.TF_WORKSPACE }}
@@ -91,13 +91,13 @@ jobs:
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
-      - name: Deploy Test Infrastrucutre
+      - name: Deploy Test Infrastructure
         uses: dflook/terraform-apply@dcda97d729f1843ede471d2fac989cb946f5622a # v1
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else
               eval "${{ inputs.tf_pre_run }}"
             fi

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -106,7 +106,7 @@ jobs:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
             if [ -z "${{ inputs.tf_pre_run }}" ]; then
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
+              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "awscliv2.zip" && unzip -qq -o awscliv2.zip && ./aws/install
             else
               eval "${{ inputs.tf_pre_run }}"
             fi

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -112,7 +112,7 @@ jobs:
             fi
         with:
           label: ${{ inputs.environment}}
-          add_github_comment: ${{ inputs.github_comment }}
+          add_github_comment: ${{ inputs.gh_comment }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}


### PR DESCRIPTION
if the awscli install runs twice, there are conflicting files since the unpack is in the workspace directory

Another option is to install the aws cli bin into the workspace directory and create a dedicated step for required tools. This would need some extra thought so I will implement the simplest solution for now that works