### PR TITLE
FUM3284 - Make outputs available

### DIFF
--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -14,6 +14,20 @@ jobs:
       environment: sandbox
       tf_workspace: test/slash/replacement
 
+  test_tf_outputs_to_json:
+    needs: test_tf_feature
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show Terraform Outputs
+        run: echo "${{ toJson(needs.test_tf_feature.outputs.tf_outputs) }}"
+
+  test_tf_outputs_from_json:
+    needs: test_tf_feature
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show Terraform Outputs
+        run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs) }}"
+
   test_tf_plan:
     needs: test_tf_feature
     uses: ./.github/workflows/tf-plan.yaml

--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -21,13 +21,6 @@ jobs:
       - name: Show Terraform Outputs
         run: echo "${{ needs.test_tf_feature.outputs.tf_outputs }}"
 
-  test_tf_outputs_to_json:
-    needs: test_tf_feature
-    runs-on: ubuntu-latest
-    steps:
-      - name: Show Terraform Outputs
-        run: echo "${{ toJson(needs.test_tf_feature.outputs.tf_outputs) }}"
-
   test_tf_outputs_decode_random_pet:
     needs: test_tf_feature
     runs-on: ubuntu-latest

--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -14,6 +14,13 @@ jobs:
       environment: sandbox
       tf_workspace: test/slash/replacement
 
+  test_tf_outputs:
+    needs: test_tf_feature
+    runs-on: ubuntu-latest
+    steps:
+      - name: Show Terraform Outputs
+        run: echo "${{ needs.test_tf_feature.outputs.tf_outputs }}"
+
   test_tf_outputs_to_json:
     needs: test_tf_feature
     runs-on: ubuntu-latest

--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -28,12 +28,12 @@ jobs:
       - name: Show Terraform Outputs
         run: echo "${{ toJson(needs.test_tf_feature.outputs.tf_outputs) }}"
 
-  test_tf_outputs_from_json:
+  test_tf_outputs_decode_random_pet:
     needs: test_tf_feature
     runs-on: ubuntu-latest
     steps:
-      - name: Show Terraform Outputs
-        run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs) }}"
+      - name: Show Random pets
+        run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs).random_pet }}"
 
   test_tf_plan:
     needs: test_tf_feature

--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -25,7 +25,7 @@ jobs:
     needs: test_tf_feature
     runs-on: ubuntu-latest
     steps:
-      - name: Show Random pets
+      - name: Show random_pet output resource
         run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs).random_pet }}"
 
   test_tf_plan:

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -41,8 +41,14 @@ on:
       tf_pre_run:
         description: "Command to run before Terraform is executed."
         type: string
+    outputs:
+      tf_outputs:
+        description: "List of Terraform outputs captured."
+        value: ${{ jobs.apply.outputs.tf_outputs }}
 jobs:
   apply:
+    outputs:
+      tf_outputs: ${{ toJson(steps.tf_apply.outputs) }}
     permissions:
       contents: read
       id-token: write
@@ -81,6 +87,7 @@ jobs:
           path: ${{ env.GH_ARTIFACT_PATH }}
 
       - name: Terraform Apply
+        id: tf_apply
         uses: dflook/terraform-apply@dcda97d729f1843ede471d2fac989cb946f5622a # v1
         env:
           TERRAFORM_PRE_RUN: |
@@ -98,3 +105,16 @@ jobs:
           var_file: ${{ env.TF_VAR_FILES }}
           variables: ${{ env.TF_VARS }}
           auto_approve: true
+
+
+      - name: Create Summary Output
+        id: tf_outputs_summary
+        run: |
+          echo "Summary" >> $GITHUB_STEP_SUMMARY
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "<summary>Terraform Outputs</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ toJson(steps.tf_apply.outputs) }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -108,6 +108,7 @@ jobs:
 
 
       - name: Create Summary Output
+        if: steps.tf_apply.outputs != ''
         id: tf_outputs_summary
         run: |
           echo "Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -131,10 +131,7 @@ jobs:
             echo "outputs<<${delimiter}"
             echo "$TERRAFORM_SUMMARY_HEADER"
             echo "<details><summary>Click to expand</summary>"
-            echo ""
-            echo '```terraform'
             echo "${TERRAFORM_OUTPUTS}"
-            echo '```'
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -135,12 +135,6 @@ jobs:
             echo '```terraform'
             echo "${TERRAFORM_OUTPUTS}"
             echo '```'
-            echo ""
-            echo ${{ toJson(steps.tf_apply.outputs) }}
-            echo ""
-            echo "${{ toJson(steps.tf_apply.outputs) }}"
-            echo ""
-            echo "${{ steps.tf_apply.outputs }}"
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -128,6 +128,7 @@ jobs:
           TERRAFORM_OUTPUTS='${{ toJson(steps.tf_apply.outputs) }}'
           delimiter="$(openssl rand -hex 8)"
           {
+            echo "outputs<<"
             echo "$TERRAFORM_SUMMARY_HEADER"
             echo "<details><summary>Click to expand</summary>"
             echo ""

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -131,7 +131,10 @@ jobs:
             echo "outputs<<${delimiter}"
             echo "$TERRAFORM_SUMMARY_HEADER"
             echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```json'
             echo "${TERRAFORM_OUTPUTS}"
+            echo '```'
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -139,11 +139,13 @@ jobs:
             echo ${{ toJson(steps.tf_apply.outputs) }}
             echo ""
             echo "${{ toJson(steps.tf_apply.outputs) }}"
+            echo ""
+            echo "${{ steps.tf_apply.outputs }}"
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT
 
       - name: Publish Terraform Outputs to Task Summary
         env:
-          SUMMARY: ${{ steps.tf-output-string.outputs }}
+          SUMMARY: ${{ toJson(steps.tf-output-string.outputs) }}
         run: echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -121,25 +121,14 @@ jobs:
           variables: ${{ env.TF_VARS }}
           auto_approve: true
 
-      - name: Create String Output
+      - name: Create Summary Output
         id: tf-output-string
         run: |
-          TERRAFORM_SUMMARY_HEADER='Terraform Outputs:'
-          TERRAFORM_OUTPUTS='${{ toJson(steps.tf_apply.outputs) }}'
-          delimiter="$(openssl rand -hex 8)"
-          {
-            echo "outputs<<${delimiter}"
-            echo "$TERRAFORM_SUMMARY_HEADER"
-            echo "<details><summary>Click to expand</summary>"
-            echo ""
-            echo '```json'
-            echo "${TERRAFORM_OUTPUTS}"
-            echo '```'
-            echo "</details>"
-            echo "${delimiter}"
-          } >> $GITHUB_OUTPUT
-
-      - name: Publish Terraform Outputs to Task Summary
-        env:
-          SUMMARY: ${{ toJson(steps.tf-output-string.outputs) }}
-        run: echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+          echo "Summary" >> $GITHUB_STEP_SUMMARY
+          echo "<details>" >> $GITHUB_STEP_SUMMARY
+          echo "<summary>Terraform Outputs</summary>" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo "${{ toJson(steps.tf_apply.outputs) }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -128,7 +128,7 @@ jobs:
           echo "<details>" >> $GITHUB_STEP_SUMMARY
           echo "<summary>Terraform Outputs</summary>" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
           echo "${{ toJson(steps.tf_apply.outputs) }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -48,7 +48,7 @@ on:
 jobs:
   feature:
     outputs:
-      tf_outputs: ${{ steps.tf_apply.outputs }}
+      tf_outputs: ${{ fromJson(steps.tf_apply.outputs) }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -122,7 +122,7 @@ jobs:
           auto_approve: true
 
       - name: Create Summary Output
-        id: tf-output-string
+        id: tf_outputs_summary
         run: |
           echo "Summary" >> $GITHUB_STEP_SUMMARY
           echo "<details>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -120,3 +120,26 @@ jobs:
           var_file: ${{ env.TF_VAR_FILES }}
           variables: ${{ env.TF_VARS }}
           auto_approve: true
+
+      - name: Create String Output
+        id: tf-output-string
+        run: |
+          TERRAFORM_SUMMARY_HEADER='Terraform Outputs:'
+          TERRAFORM_OUTPUTS='${{ toJson(steps.tf_apply.outputs) }}'
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "outputs<<${delimiter}"
+            echo "$TERRAFORM_SUMMARY_HEADER"
+            echo "<details><summary>Click to expand</summary>"
+            echo ""
+            echo '```terraform'
+            echo "${TERRAFORM_OUTPUTS}"
+            echo '```'
+            echo "</details>"
+            echo "${delimiter}"
+          } >> $GITHUB_OUTPUT
+
+      - name: Publish Terraform Outputs to Task Summary
+        env:
+          SUMMARY: ${{ toJson(steps.tf-output-string.outputs) }}
+        run: echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -128,7 +128,6 @@ jobs:
           TERRAFORM_OUTPUTS='${{ toJson(steps.tf_apply.outputs) }}'
           delimiter="$(openssl rand -hex 8)"
           {
-            echo "outputs<<${delimiter}"
             echo "$TERRAFORM_SUMMARY_HEADER"
             echo "<details><summary>Click to expand</summary>"
             echo ""
@@ -136,7 +135,6 @@ jobs:
             echo "${TERRAFORM_OUTPUTS}"
             echo '```'
             echo "</details>"
-            echo "${delimiter}"
           } >> $GITHUB_OUTPUT
 
       - name: Publish Terraform Outputs to Task Summary

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -135,7 +135,10 @@ jobs:
             echo '```terraform'
             echo "${TERRAFORM_OUTPUTS}"
             echo '```'
-            echo "${TERRAFORM_OUTPUTS}"
+            echo ""
+            echo "${TERRAFORM_OUTPUTS}" | jq -r '. | to_entries | .[] | .key + " = " + .value.value' | while read line; do
+              echo "${line}"
+            done
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -41,8 +41,14 @@ on:
       tf_workspace:
         description: "Terraform workspace"
         type: string
+    outputs:
+      tf_outputs:
+        description: "List of Terraform outputs captured."
+        value: ${{ jobs.feature.outputs.tf_outputs }}
 jobs:
   feature:
+    outputs:
+      tf_outputs: ${{ steps.tf_apply.outputs }}
     permissions:
       contents: read
       id-token: write
@@ -96,6 +102,7 @@ jobs:
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
 
       - name: Deploy Test Infrastructure
+        id: tf_apply
         uses: dflook/terraform-apply@dcda97d729f1843ede471d2fac989cb946f5622a # v1
         env:
           TERRAFORM_PRE_RUN: |

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -48,7 +48,7 @@ on:
 jobs:
   feature:
     outputs:
-      tf_outputs: ${{ fromJson(steps.tf_apply.outputs) }}
+      tf_outputs: ${{ toJson(steps.tf_apply.outputs) }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -136,14 +136,14 @@ jobs:
             echo "${TERRAFORM_OUTPUTS}"
             echo '```'
             echo ""
-            echo "${TERRAFORM_OUTPUTS}" | jq -r '. | to_entries | .[] | .key + " = " + .value.value' | while read line; do
-              echo "${line}"
-            done
+            echo ${{ toJson(steps.tf_apply.outputs) }}
+            echo ""
+            echo "${{ toJson(steps.tf_apply.outputs) }}"
             echo "</details>"
             echo "${delimiter}"
           } >> $GITHUB_OUTPUT
 
       - name: Publish Terraform Outputs to Task Summary
         env:
-          SUMMARY: ${{ toJson(steps.tf-output-string.outputs) }}
+          SUMMARY: ${{ steps.tf-output-string.outputs }}
         run: echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -122,6 +122,7 @@ jobs:
           auto_approve: true
 
       - name: Create Summary Output
+        if: steps.tf_apply.outputs != ''
         id: tf_outputs_summary
         run: |
           echo "Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -128,14 +128,16 @@ jobs:
           TERRAFORM_OUTPUTS='${{ toJson(steps.tf_apply.outputs) }}'
           delimiter="$(openssl rand -hex 8)"
           {
-            echo "outputs<<"
+            echo "outputs<<${delimiter}"
             echo "$TERRAFORM_SUMMARY_HEADER"
             echo "<details><summary>Click to expand</summary>"
             echo ""
             echo '```terraform'
             echo "${TERRAFORM_OUTPUTS}"
             echo '```'
+            echo "${TERRAFORM_OUTPUTS}"
             echo "</details>"
+            echo "${delimiter}"
           } >> $GITHUB_OUTPUT
 
       - name: Publish Terraform Outputs to Task Summary


### PR DESCRIPTION
## Description
This PR adds a way to retrieve terraform outputs for using them in possible next jobs. It also shows a clean and sexy summary of all existing terraform outputs in a json like format. It's then easy for the caller to find one output he needs and can reuse in follow up jobs.

## Motivation and Context
When another job depends on a terraform job, it is useful to have the terraform outputs available for the next job to use and not use some magic to guess the value.

## Breaking Changes
No breaking changes, more features :rocket:

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
This has been tested adding a couple testing steps. One shows the full output extracted from the shared workflow, the other one shows a specific output value directly extracted from the output json.
See https://github.com/tx-pts-dai/github-workflows/blob/66074b51bd94bffc61f97dda4696c439f20cfb0b/.github/workflows/_test-tf.yaml#L17

Sample of outputs summary: 
![image](https://github.com/user-attachments/assets/7d976cb4-3add-4c93-a465-ce9df361bb1e)

