### PR TITLE
feat: add summary action

### DIFF
--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -69,7 +69,7 @@ jobs:
         file_path="artifact-sample.txt"
 
   test_tf_artifact_all:
-    needs: test_upload_artifact
+    needs: test_tf_artifact
     uses: ./.github/workflows/tf-plan.yaml
     with:
       environment: sandbox

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -111,15 +111,10 @@ jobs:
           variables: ${{ env.TF_VARS }}
           auto_approve: true
 
-      - name: Create Summary Output
+      - name: Summary
         if: steps.tf_apply.outputs != ''
-        id: tf_outputs_summary
-        run: |
-          echo "Summary" >> $GITHUB_STEP_SUMMARY
-          echo "<details>" >> $GITHUB_STEP_SUMMARY
-          echo "<summary>Terraform Outputs</summary>" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ toJson(steps.tf_apply.outputs) }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
+        uses: tx-pts-dai/action-summary@v0.0.2
+        with:
+          summary_header: "Terraform Outputs"
+          string: ${{ toJson(steps.tf_apply.outputs) }}
+          data_type: "json"

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -126,15 +126,10 @@ jobs:
           variables: ${{ env.TF_VARS }}
           auto_approve: true
 
-      - name: Create Summary Output
+      - name: Summary
         if: steps.tf_apply.outputs != ''
-        id: tf_outputs_summary
-        run: |
-          echo "Summary" >> $GITHUB_STEP_SUMMARY
-          echo "<details>" >> $GITHUB_STEP_SUMMARY
-          echo "<summary>Terraform Outputs</summary>" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "${{ toJson(steps.tf_apply.outputs) }}" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
+        uses: tx-pts-dai/action-summary@v0.0.2
+        with:
+          summary_header: "Terraform Outputs"
+          string: ${{ toJson(steps.tf_apply.outputs) }}
+          data_type: "json"

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -125,38 +125,10 @@ jobs:
           var_file: ${{ env.TF_VAR_FILES }}
           variables: ${{ env.TF_VARS }}
 
-      # TODO Convert to composite run steps
-      - name: Create String Output
+      - name: Summary
         if: github.event_name == 'pull_request'
-        id: tf-plan-string
-        env:
-          TERRAFORM_PLAN_PATH: ${{ steps.plan.outputs.text_plan_path }}
-        run: |
-          MAX_PLAN_LENGTH=120000
-          TERRAFORM_PLAN=$(cat $TERRAFORM_PLAN_PATH)
-          TERRAFORM_SUMMARY_HEADER=$(grep -E -i -m 1 'No changes|Plan:|Outputs:' <<< "$TERRAFORM_PLAN")
-          PLAN_LENGTH=${#TERRAFORM_PLAN}
-          START=$((PLAN_LENGTH - MAX_PLAN_LENGTH))
-          if [ "$START" -lt 0 ]; then
-            SHORT_PLAN=${TERRAFORM_PLAN}
-          else
-            echo ":warning: Plan output is too long to be displayed (${PLAN_LENGTH} chars). Only the last ${MAX_PLAN_LENGTH} characters will be printed. "
-            SHORT_PLAN=${TERRAFORM_PLAN:START:MAX_PLAN_LENGTH}
-          fi
-          delimiter="$(openssl rand -hex 8)"
-          echo "summary<<${delimiter}" >> $GITHUB_OUTPUT
-          echo "$TERRAFORM_SUMMARY_HEADER" >> $GITHUB_OUTPUT
-          echo "<details><summary>Click to expand</summary>" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo '```terraform' >> $GITHUB_OUTPUT
-          echo "${SHORT_PLAN}" >> $GITHUB_OUTPUT
-          echo '```' >> $GITHUB_OUTPUT
-          echo "</details>" >> $GITHUB_OUTPUT
-          echo "${delimiter}" >> $GITHUB_OUTPUT
-
-      - name: Publish Terraform Plan to Task Summary
-        if: github.event_name == 'pull_request'
-        env:
-          SUMMARY: ${{ steps.tf-plan-string.outputs.summary }}
-        run: |
-          echo "$SUMMARY" >> $GITHUB_STEP_SUMMARY
+        uses: tx-pts-dai/action-summary@v0.0.2
+        with:
+          summary_header: "Terraform Plan"
+          path: ${{ steps.plan.outputs.text_plan_path }}
+          data_type: "terraform"

--- a/tests/terraform/local/main.tf
+++ b/tests/terraform/local/main.tf
@@ -4,6 +4,16 @@ resource "random_pet" "this" {
 
 resource "random_id" "this" {
   byte_length = 4
+
+  keepers = {
+    null_resource_id = null_resource.test.id
+  }
+}
+
+resource "null_resource" "test" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
 }
 
 output "random_pet" {


### PR DESCRIPTION
## Description
Add Summary Action

## Motivation and Context
Reuse code where you can and not manage multiple inline bash scripts within the workflows. 

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
