### PR TITLE
use runs-on from input

### DIFF
--- a/.github/workflows/docker-push-ecr.yaml
+++ b/.github/workflows/docker-push-ecr.yaml
@@ -25,10 +25,15 @@ on:
         description: "Tag of the Docker image to build"
         type: string
         default: ${{ github.sha }}
+      runner_label: 
+        description: "json array of runners to use"
+        type: string
+        default: "['ubuntu-latest']"
+
 jobs:
   push:
     name: Push to ECR
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
     environment: ${{ inputs.environment }}
     permissions:
       id-token: write


### PR DESCRIPTION
## Description
adds input for runs-on.
## Motivation and Context
Feed wants self hosted arm based gh-runners. 

