### PR TITLE
feat!: remove concurrency groups and adjust tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,5 @@
 <!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
 <!--- Please describe how you tested your changes -->
 - [ ] I have executed `pre-commit run -a` on my pull request
-- [ ] I have executed `gen_docs_run` on my pull request
+- [ ] I have executed `make gen_docs_run` on my pull request
 <!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -29,13 +29,11 @@ jobs:
         run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs).random_pet }}"
 
   test_tf_plan:
-    needs: test_tf_feature
     uses: ./.github/workflows/tf-plan.yaml
     with:
       environment: sandbox
 
   test_tf_apply:
-    needs: test_tf_plan
     uses: ./.github/workflows/tf-apply.yaml
     with:
       environment: sandbox
@@ -47,6 +45,19 @@ jobs:
     with:
       environment: sandbox
       tf_workspace: test/slash/replacement
+
+  test_tf_plan_no_environment:
+    uses: ./.github/workflows/tf-plan.yaml
+    with:
+      aws_account_id: 911453050078
+      aws_region: eu-central-1
+      aws_role_name: cicd-iac
+      tf_dir: tests/terraform/s3
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=sandbox1.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
 
   test_upload_artifact:
     runs-on: ubuntu-latest
@@ -69,7 +80,7 @@ jobs:
         file_path="artifact-sample.txt"
 
   test_tf_artifact_all:
-    needs: test_tf_artifact
+    needs: test_upload_artifact
     uses: ./.github/workflows/tf-plan.yaml
     with:
       environment: sandbox

--- a/.github/workflows/aws-secrets-copy.yaml
+++ b/.github/workflows/aws-secrets-copy.yaml
@@ -40,9 +40,6 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.destination_aws_oidc_role_arn }}-${{ inputs.destination_secret_name}}
-      cancel-in-progress: true
     steps:
       - name: Configure Source AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -56,12 +56,10 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ inputs.environment }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
+      ENVIRONMENT: ${{ inputs.environment }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_DIR: ${{ inputs.tf_dir || vars.tf_dir || '.' }}
       TF_BACKEND_CONFIGS: ${{ inputs.tf_backend_configs || vars.tf_backend_configs }}
@@ -103,7 +101,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          label: ${{ inputs.environment }}
+          label: ${{ env.ENVIRONMENT }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
           backend_config_file: ${{ env.TF_BACKEND_CONFIG_FILES }}
@@ -115,6 +113,6 @@ jobs:
         if: steps.tf_apply.outputs != ''
         uses: tx-pts-dai/action-summary@v0.0.2
         with:
-          summary_header: "Terraform Outputs"
+          summary_header: "Terraform Outputs | ${{ env.ENVIRONMENT}}"
           string: ${{ toJson(steps.tf_apply.outputs) }}
           data_type: "json"

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -47,9 +47,6 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ inputs.environment }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:

--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || null }}
     env:
+      ENVIRONMENT: ${{ inputs.environment }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_DIR: ${{ inputs.tf_dir || vars.tf_dir || '.' }}
       TF_BACKEND_CONFIGS: ${{ inputs.tf_backend_configs || vars.tf_backend_configs }}

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -56,9 +56,6 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ inputs.environment }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
@@ -130,6 +127,6 @@ jobs:
         if: steps.tf_apply.outputs != ''
         uses: tx-pts-dai/action-summary@v0.0.2
         with:
-          summary_header: "Terraform Outputs"
+          summary_header: "Terraform Outputs | ${{ env.ENVIRONMENT}}"
           string: ${{ toJson(steps.tf_apply.outputs) }}
           data_type: "json"

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -56,12 +56,10 @@ jobs:
       contents: read
       id-token: write
       pull-requests: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ inputs.environment }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:
+      ENVIRONMENT: ${{ inputs.environment }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       TF_DIR: ${{ inputs.tf_dir || vars.tf_dir || '.' }}
       TF_BACKEND_CONFIGS: ${{ inputs.tf_backend_configs || vars.tf_backend_configs }}
@@ -117,7 +115,7 @@ jobs:
               eval "${{ inputs.tf_pre_run }}"
             fi
         with:
-          label: ${{ inputs.environment}}
+          label: ${{ env.ENVIRONMENT }}
           add_github_comment: ${{ inputs.gh_comment }}
           path: ${{ env.TF_DIR}}
           backend_config: ${{ env.TF_BACKEND_CONFIGS }}
@@ -129,6 +127,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: tx-pts-dai/action-summary@v0.0.2
         with:
-          summary_header: "Terraform Plan"
+          summary_header: "Terraform Plan | ${{ env.ENVIRONMENT}} "
           path: ${{ steps.plan.outputs.text_plan_path }}
           data_type: "terraform"

--- a/tests/terraform/s3/main.tf
+++ b/tests/terraform/s3/main.tf
@@ -1,5 +1,8 @@
 terraform {
-  backend "s3" {}
+  backend "s3" {
+    dynamodb_table = "terraform-lock"
+    region         = "eu-central-1"
+  }
 }
 
 resource "random_pet" "this" {


### PR DESCRIPTION
## Description
Remove concurrency groups from reusable workflows

## Motivation and Context
it was causing issues in disco where they dont use environments so jobs were getting canceled. The logic is better to have where its needed

## Breaking Changes
Some piplines might run concurrently but this is not an issue for terraform since we use locks 
## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
