### PR TITLE
feat: allow checking out any ref

### DIFF
--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -88,3 +88,15 @@ jobs:
       gh_artifact_path: tests/terraform/artifact/
       tf_vars: |
         file_path="docker-artifacts/artifact-sample.txt"
+
+  test_tf_checkout_ref:
+    uses: ./.github/workflows/tf-plan.yaml
+    with:
+      environment: sandbox
+      gh_checkout_ref: refs/heads/main
+      tf_dir: tests/terraform/s3
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=sandbox-checkout-ref.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars

--- a/.github/workflows/tf-apply.yaml
+++ b/.github/workflows/tf-apply.yaml
@@ -26,6 +26,9 @@ on:
       gh_artifact_name:
         description: "Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded."
         type: string
+      gh_checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        type: string
       tf_dir:
         description: "Path to the Terraform root module to apply."
         type: string
@@ -69,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          ref: ${{ inputs.gh_checkout_ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -20,6 +20,9 @@ on:
       aws_oidc_role_arn:
         description: "AWS OIDC IAM role to assume"
         type: string
+      gh_checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        type: string
       tf_dir:
         description: "Terraform directory"
         type: string
@@ -66,6 +69,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          ref: ${{ inputs.gh_checkout_ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -17,6 +17,9 @@ on:
       aws_oidc_role_arn:
         description: "AWS OIDC IAM role to assume"
         type: string
+      gh_checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        type: string
       tf_dir:
         description: "Path to the Terraform root module to apply."
         type: string
@@ -54,6 +57,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          ref: ${{ inputs.gh_checkout_ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/tf-feature.yaml
+++ b/.github/workflows/tf-feature.yaml
@@ -23,6 +23,9 @@ on:
       gh_artifact_name:
         description: "Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded."
         type: string
+      gh_checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        type: string
       tf_dir:
         description: "Terraform directory"
         type: string
@@ -75,6 +78,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          ref: ${{ inputs.gh_checkout_ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/.github/workflows/tf-plan.yaml
+++ b/.github/workflows/tf-plan.yaml
@@ -28,6 +28,9 @@ on:
       gh_artifact_name:
         description: "Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded."
         type: string
+      gh_checkout_ref:
+        description: "The branch, tag or SHA to checkout."
+        type: string
       gh_comment:
         description: "Whether to post a comment on the PR with the Terraform plan"
         type: string
@@ -69,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+        with:
+          ref: ${{ inputs.gh_checkout_ref }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4

--- a/docs/workflows/tf-apply.md
+++ b/docs/workflows/tf-apply.md
@@ -22,6 +22,7 @@ This workflow applies the Terraform configuration.
 | `aws_oidc_role_arn` | <p>AWS OIDC IAM role to assume</p> | `string` | `false` | `""` |
 | `gh_artifact_path` | <p>Path to download artifacts to. If unset, default action workspace is used. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
 | `gh_artifact_name` | <p>Name of the artifact to download. If only 'gh<em>artifact</em>path' is set, then all artifacts are downloaded. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
+| `gh_checkout_ref` | <p>The branch, tag or SHA to checkout.</p> | `string` | `false` | `""` |
 | `tf_dir` | <p>Path to the Terraform root module to apply.</p> | `string` | `false` | `""` |
 | `tf_backend_configs` | <p>ist of Terraform backend config values, one per line.</p> | `string` | `false` | `""` |
 | `tf_backend_config_files` | <p>List of Terraform backend config files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
@@ -90,6 +91,13 @@ jobs:
 
       gh_artifact_name:
       # Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      gh_checkout_ref:
+      # The branch, tag or SHA to checkout.
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-cleanup.md
+++ b/docs/workflows/tf-cleanup.md
@@ -20,6 +20,7 @@ This workflow cleans up the Terraform preview deployments.
 | `aws_region` | <p>The AWS region.</p> | `string` | `false` | `""` |
 | `aws_role_name` | <p>The name of the role to assume with OIDC.</p> | `string` | `false` | `""` |
 | `aws_oidc_role_arn` | <p>AWS OIDC IAM role to assume</p> | `string` | `false` | `""` |
+| `gh_checkout_ref` | <p>The branch, tag or SHA to checkout.</p> | `string` | `false` | `""` |
 | `tf_dir` | <p>Terraform directory</p> | `string` | `false` | `""` |
 | `tf_backend_configs` | <p>Terraform backend config cli arguments</p> | `string` | `false` | `""` |
 | `tf_backend_config_files` | <p>List of Terraform backend config files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
@@ -71,6 +72,13 @@ jobs:
 
       aws_oidc_role_arn:
       # AWS OIDC IAM role to assume
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      gh_checkout_ref:
+      # The branch, tag or SHA to checkout.
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-destroy.md
+++ b/docs/workflows/tf-destroy.md
@@ -20,6 +20,7 @@ This workflow destroys Terraform resources.
 | `aws_region` | <p>The AWS region.</p> | `string` | `false` | `""` |
 | `aws_role_name` | <p>The name of the role to assume with OIDC.</p> | `string` | `false` | `""` |
 | `aws_oidc_role_arn` | <p>AWS OIDC IAM role to assume</p> | `string` | `false` | `""` |
+| `gh_checkout_ref` | <p>The branch, tag or SHA to checkout.</p> | `string` | `false` | `""` |
 | `tf_dir` | <p>Path to the Terraform root module to apply.</p> | `string` | `false` | `""` |
 | `tf_backend_configs` | <p>List of Terraform backend config values, one per line.</p> | `string` | `false` | `""` |
 | `tf_backend_config_files` | <p>List of Terraform backend config files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
@@ -70,6 +71,13 @@ jobs:
 
       aws_oidc_role_arn:
       # AWS OIDC IAM role to assume
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      gh_checkout_ref:
+      # The branch, tag or SHA to checkout.
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-feature.md
+++ b/docs/workflows/tf-feature.md
@@ -21,6 +21,7 @@ This workflow deploys a Terraform configuration to a preview environment.
 | `aws_account_id` | <p>The AWS account ID.</p> | `string` | `false` | `""` |
 | `gh_artifact_path` | <p>Path to download artifacts to. If unset, default action workspace is used. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
 | `gh_artifact_name` | <p>Name of the artifact to download. If only 'gh<em>artifact</em>path' is set, then all artifacts are downloaded. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
+| `gh_checkout_ref` | <p>The branch, tag or SHA to checkout.</p> | `string` | `false` | `""` |
 | `tf_dir` | <p>Terraform directory</p> | `string` | `false` | `""` |
 | `tf_backend_configs` | <p>Terraform backend config cli arguments</p> | `string` | `false` | `""` |
 | `tf_backend_config_files` | <p>List of Terraform backend config files to use, one per line. Paths should be relative to the GitHub Actions workspace.</p> | `string` | `false` | `""` |
@@ -83,6 +84,13 @@ jobs:
 
       gh_artifact_name:
       # Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      gh_checkout_ref:
+      # The branch, tag or SHA to checkout.
       #
       # Type: string
       # Required: false

--- a/docs/workflows/tf-plan.md
+++ b/docs/workflows/tf-plan.md
@@ -22,6 +22,7 @@ This workflow runs `terraform plan` and uploads the plan to Github Action summar
 | `aws_oidc_role_arn` | <p>AWS OIDC IAM role to assume</p> | `string` | `false` | `""` |
 | `gh_artifact_path` | <p>Path to download artifacts to. If unset, default action workspace is used. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
 | `gh_artifact_name` | <p>Name of the artifact to download. If only 'gh<em>artifact</em>path' is set, then all artifacts are downloaded. If both 'gh<em>artifact</em>path' and 'gh<em>artifact</em>name' are unset, artifacts are not downloaded.</p> | `string` | `false` | `""` |
+| `gh_checkout_ref` | <p>The branch, tag or SHA to checkout.</p> | `string` | `false` | `""` |
 | `gh_comment` | <p>Whether to post a comment on the PR with the Terraform plan</p> | `string` | `false` | `changes-only` |
 | `tf_dir` | <p>Path to the Terraform root module to apply.</p> | `string` | `false` | `""` |
 | `tf_backend_configs` | <p>List of Terraform backend config values, one per line.</p> | `string` | `false` | `""` |
@@ -87,6 +88,13 @@ jobs:
 
       gh_artifact_name:
       # Name of the artifact to download. If only 'gh_artifact_path' is set, then all artifacts are downloaded. If both 'gh_artifact_path' and 'gh_artifact_name' are unset, artifacts are not downloaded.
+      #
+      # Type: string
+      # Required: false
+      # Default: ""
+
+      gh_checkout_ref:
+      # The branch, tag or SHA to checkout.
       #
       # Type: string
       # Required: false


### PR DESCRIPTION
## Description
Allow checkout out a branch with a ref

## Motivation and Context
Allows for trigging a workflow with an issue comment and checking out the branch where the issue (pr comment) was made

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
