### PR TITLE
Fe 1441 advanced docker build push ecr

### DIFF
--- a/.github/workflows/_test-docker.yaml
+++ b/.github/workflows/_test-docker.yaml
@@ -72,3 +72,38 @@ jobs:
       docker_context: tests/docker
       docker_push: false
       artifact_name: docker-artifacts
+
+  prep_test_docker_build_push_ecr_advanced:
+    id: docker_meta
+    uses: docker/metadata-action@v5
+    with:
+      images: 488017668515.dkr.ecr.eu-central-1.amazonaws.com/sam
+      tags: |
+        type=ref,event=pr
+        type=semver,pattern={{version}}
+        type=semver,pattern={{major}}.{{minor}}
+        type=raw,${{ steps.current-time.outputs.formattedTime }}.${{ github.run_number }}
+        type=raw,{{branch}}.${{ github.run_number }}
+      labels: |
+        org.opencontainers.image.title=Feed Sam Service
+        org.opencontainers.image.description=Feed image rendering service
+        org.opencontainers.image.vendor=tx.group
+        org.opencontainers.image.authors=Christian Jürges
+    outputs:
+      tags: ${{ steps.docker_meta.outputs.tags }}
+      labels: ${{ steps.docker_meta.outputs.labels }}
+      docker_build_args: |
+        GO_VERSION=${{ env.GO_VERSION }}
+        ALPINE_VERSION=${{ env.ALPINE_VERSION }}
+
+  test_docker_build_push_ecr_advanced:
+    needs: prep_test_docker_build_push_ecr_advanced
+    uses: ./.github/workflows/docker-build-push-ecr-advanced.yaml
+    with:
+      aws_account_id: ${{ vars.aws_account_id }}
+      aws_region: ${{ vars.aws_region }}
+      aws_role_name: ${{ vars.aws_role_name }}
+      dockerfile_path: tests/docker/alpine/build/Dockerfile
+      image_tags: ${{ toJSON(needs.prep_test_docker_build_push_ecr_advanced.outputs.tags) }}
+      image_labels: ${{ toJSON(needs.prep_test_docker_build_push_ecr_advanced.outputs.labels) }}
+      docker_build_args: ${{ needs.prep_test_docker_build_push_ecr_advanced.outputs.docker_build_args }}

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -1,0 +1,123 @@
+name: Docker Build and Push to ECR
+
+on:
+  workflow_call:
+    secrets:
+      docker_secrets:
+        description: "Comma-delimited list of Github secrets to pass to docker build workflow"
+        required: false
+    inputs:
+      environment:
+        description: "Environment to run the build in"
+        type: string
+      aws_account_id:
+        description: "AWS Account ID"
+        type: string
+      aws_region:
+        description: "AWS Region"
+        type: string
+      aws_role_name:
+        description: "AWS Role Name"
+        type: string
+      aws_oidc_role_arn:
+        description: "AWS OIDC IAM role to assume"
+        type: string
+      image_tags:
+        description: "JSON array string with full repo/image:tag list"
+        type: string
+        required: true
+      image_labels:
+        description: "JSON object string with image labels"
+        type: string
+        default: '{}'
+      docker_context:
+        description: "Path to the build context"
+        type: string
+      dockerfile_path:
+        description: "Path to the Dockerfile. If not defined, will default to {docker_context}/Dockerfile"
+        type: string
+      docker_push:
+        description: "Push Image to ECR"
+        type: boolean
+        default: true
+      docker_target:
+        description: "Build target"
+        type: string
+      artifact_name:
+        description: "Artifact name to be downloaded before building"
+        type: string
+      artifact_path:
+        description: "Artifact target path"
+        type: string
+      runner_labels:
+        description: "Runner that the main job should run on as JSON encoded list."
+        type: string
+        default: " ['ubuntu-latest'] "
+
+jobs:
+  prereq: # this job is required to pass the runner_labels to the build job!
+    runs-on: ubuntu-latest
+    steps:
+      - name: Provision step # at least one step is required in a job
+        run: |
+          echo "Provisioning ${{ inputs.runner_labels }}"
+    outputs:
+      runner_labels: ${{ inputs.runner_labels }}
+  build:
+    needs: prereq
+    runs-on: ${{ fromJSON(needs.prereq.outputs.runner_labels) }}
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+
+      - name: Download artifacts to pass to docker build
+        if: ${{ inputs.artifact_name || inputs.artifact_path }} # avoid downloading artifacts if not needed
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact_name || vars.artifact_name }}
+          ARTIFACT_PATH: ${{ inputs.artifact_path || vars.artifact_path }}
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.ARTIFACT_PATH }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        env:
+          ROLE_TO_ASSUME: ${{ inputs.aws_oidc_role_arn || vars.aws_oidc_role_arn || format('arn:aws:iam::{0}:role/{1}', inputs.aws_account_id, inputs.aws_role_name) }}
+          AWS_REGION: ${{ inputs.aws_region || vars.aws_region || 'eu-central-1' }}
+        with:
+          role-to-assume: ${{ env.ROLE_TO_ASSUME }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+
+      - name: Build and export
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
+          DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
+          DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}
+        with:
+          context: ${{ env.DOCKER_CTX }}
+          file: ${{ env.DOCKERFILE_PATH }}
+          secrets: ${{ secrets.docker_secrets }}
+          # platforms: linux/amd64,linux/arm64 # TODO add support for multi-arch builds
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: ${{ inputs.docker_push }}
+          target: ${{ env.DOCKER_TARGET }}
+          tags: ${{ fromJSON(inputs.image_tags) }}
+          labels: ${{ fromJSON(inputs.image_labels) }}
+

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -68,10 +68,12 @@ jobs:
         name: Provision step # at least one step is required in a job
         run: |
           echo "image tags: ${{ inputs.image_tags }}"
+          echo "image labels: ${{ inputs.image_labels }}"
 
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
       image_tags: ${{ inputs.image_tags }}
+      image_labels: ${{ inputs.image_labels }}
 
   build:
     needs: prereq
@@ -126,5 +128,5 @@ jobs:
           push: ${{ inputs.docker_push }}
           target: ${{ env.DOCKER_TARGET }}
           tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
-          # labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
+          labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
 

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -30,6 +30,10 @@ on:
         description: "JSON object string with image labels"
         type: string
         default: "{}"
+      docker_build_args:
+        description: "JSON array string with build args"
+        type: string
+        default: "[]"
       docker_context:
         description: "Path to the build context"
         type: string
@@ -53,6 +57,7 @@ on:
         description: "Runner that the main job should run on as JSON encoded list."
         type: string
         default: " ['ubuntu-latest'] "
+
 
 jobs:
   prereq: # this job is required to pass the runner_labels to the build job!

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -65,11 +65,13 @@ jobs:
     steps:
       - name: Provision step # at least one step is required in a job
         run: |
-          echo "Provisioning ${{ inputs.runner_labels }}"
+          echo "image_tags=${{ inputs.runner_tags }}" >> $GITHUB_OUTPUT
+          echo "image_labels=${{ inputs.runner_labels }}" >> $GITHUB_OUTPUT
+
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
-      image_tags: ${{ inputs.image_tags }}
-      image_labels: ${{ inputs.image_labels }}
+
+
 
   build:
     needs: prereq

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -131,5 +131,5 @@ jobs:
           target: ${{ env.DOCKER_TARGET }}
           tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
           labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
-          build-args: ${{ fromJSON(needs.prereq.outputs.build_args) }}
+          build-args: ${{ needs.prereq.outputs.build_args }}
 

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -29,7 +29,7 @@ on:
       image_labels:
         description: "JSON object string with image labels"
         type: string
-        default: '{}'
+        default: "{}"
       docker_context:
         description: "Path to the build context"
         type: string
@@ -103,9 +103,6 @@ jobs:
       - name: Build and export
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: ${{ inputs.image_name || vars.image_name || github.event.repository.name }}
-          IMAGE_TAG: ${{ inputs.image_tag }}
           DOCKER_CTX: ${{ inputs.docker_context || vars.docker_context || '.' }}
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path || vars.dockerfile_path }} # upstream defaults to {DOCKER_CTX}/Dockerfile
           DOCKER_TARGET: ${{ inputs.docker_target || vars.docker_target }}

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -65,8 +65,8 @@ jobs:
     steps:
       - name: Provision step # at least one step is required in a job
         run: |
-          echo "image_tags=${{ inputs.runner_tags }}" >> $GITHUB_OUTPUT
-          echo "image_labels=${{ inputs.runner_labels }}" >> $GITHUB_OUTPUT
+          echo "image_tags=${{ inputs.image_tags }}" >> $GITHUB_OUTPUT
+          
 
     outputs:
       runner_labels: ${{ inputs.runner_labels }}

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -68,6 +68,9 @@ jobs:
           echo "Provisioning ${{ inputs.runner_labels }}"
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
+      image_tags: ${{ inputs.image_tags }}
+      image_labels: ${{ inputs.image_labels }}
+
   build:
     needs: prereq
     runs-on: ${{ fromJSON(needs.prereq.outputs.runner_labels) }}
@@ -120,6 +123,6 @@ jobs:
           cache-to: type=gha,mode=max
           push: ${{ inputs.docker_push }}
           target: ${{ env.DOCKER_TARGET }}
-          tags: ${{ fromJSON(inputs.image_tags) }}
-          labels: ${{ fromJSON(inputs.image_labels) }}
+          tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
+          labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
 

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -1,4 +1,5 @@
 name: Docker Build and Push to ECR
+run-name: Docker Build and Push to ECR run by ${{ github.actor }}
 
 on:
   workflow_call:
@@ -23,15 +24,15 @@ on:
         description: "AWS OIDC IAM role to assume"
         type: string
       image_tags:
-        description: "JSON array string with full repo/image:tag list"
+        description: "toJSON() string with full repo/image:tag list"
         type: string
         required: true
       image_labels:
-        description: "JSON object string with image labels"
+        description: "toJSON() JSON string with image labels"
         type: string
         default: "{}"
       docker_build_args:
-        description: "JSON array string with build args"
+        description: "array string with build args"
         type: string
         default: "[]"
       docker_context:
@@ -62,7 +63,6 @@ on:
 jobs:
   prereq: # this job is required to pass the runner_labels to the build job!
     runs-on: ubuntu-latest
-
     steps:
       - id: prereq
         name: Provision step # at least one step is required in a job
@@ -70,7 +70,6 @@ jobs:
           echo "image tags: ${{ inputs.image_tags }}"
           echo "image labels: ${{ inputs.image_labels }}"
           echo "build args: ${{ inputs.docker_build_args }}"
-
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
       image_tags: ${{ inputs.image_tags }}
@@ -132,4 +131,3 @@ jobs:
           tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
           labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
           build-args: ${{ needs.prereq.outputs.build_args }}
-

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -67,11 +67,11 @@ jobs:
       - id: prereq
         name: Provision step # at least one step is required in a job
         run: |
-          echo "image_tags=${{ inputs.image_tags }}" >> $GITHUB_OUTPUT
+          echo "image tags: ${{ inputs.image_tags }}"
 
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
-      image_tags: ${{ steps.prereq.outputs.image_tags }}
+      image_tags: ${{ inputs.image_tags }}
 
   build:
     needs: prereq

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -62,16 +62,16 @@ on:
 jobs:
   prereq: # this job is required to pass the runner_labels to the build job!
     runs-on: ubuntu-latest
+
     steps:
-      - name: Provision step # at least one step is required in a job
+      - id: prereq
+        name: Provision step # at least one step is required in a job
         run: |
           echo "image_tags=${{ inputs.image_tags }}" >> $GITHUB_OUTPUT
-          
 
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
-
-
+      image_tags: ${{ steps.prereq.outputs.image_tags }}
 
   build:
     needs: prereq

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -69,11 +69,13 @@ jobs:
         run: |
           echo "image tags: ${{ inputs.image_tags }}"
           echo "image labels: ${{ inputs.image_labels }}"
+          echo "build args: ${{ inputs.docker_build_args }}"
 
     outputs:
       runner_labels: ${{ inputs.runner_labels }}
       image_tags: ${{ inputs.image_tags }}
       image_labels: ${{ inputs.image_labels }}
+      build_args: ${{ inputs.docker_build_args }}
 
   build:
     needs: prereq
@@ -129,4 +131,5 @@ jobs:
           target: ${{ env.DOCKER_TARGET }}
           tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
           labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
+          build-args: ${{ fromJSON(needs.prereq.outputs.build_args) }}
 

--- a/.github/workflows/docker-build-push-ecr-advanced.yaml
+++ b/.github/workflows/docker-build-push-ecr-advanced.yaml
@@ -124,5 +124,5 @@ jobs:
           push: ${{ inputs.docker_push }}
           target: ${{ env.DOCKER_TARGET }}
           tags: ${{ fromJSON(needs.prereq.outputs.image_tags) }}
-          labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
+          # labels: ${{ fromJSON(needs.prereq.outputs.image_labels) }}
 

--- a/tests/docker/alpine/Dockerfile
+++ b/tests/docker/alpine/Dockerfile
@@ -1,0 +1,8 @@
+ARG GO_VERSION
+ARG ALPINE_VERSION
+# compile sam
+FROM public.ecr.aws/docker/library/golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder
+
+WORKDIR /app
+RUN echo "Hello, world!"
+RUN echo "Using go version ${GO_VERSION} and alpine version ${ALPINE_VERSION}"


### PR DESCRIPTION
## Description
added feed needed docker-build-push-ecr-advanced.yaml 

## Motivation and Context
- added possibility to specify github runners to be used for this job (input runner_labels)
- added possibility fully customised list of image tags (input image_tags)
- added possibility fully customised list of labels to be added with the docker image (input image_labels)
- added possibility to pass build args to the docker build step (input docker_build_args)

## Breaking Changes
Does not break anything. 

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
- [x] It's currently used in sam https://github.com/DND-IT/sam/pull/223 --> see https://github.com/DND-IT/sam/actions/runs/11517635484
- [ ] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
