### PR TITLE
fix: dont swallow errors on destroy runs

### DIFF
--- a/.github/workflows/_test-tf.yaml
+++ b/.github/workflows/_test-tf.yaml
@@ -28,6 +28,40 @@ jobs:
       - name: Show random_pet output resource
         run: echo "${{ fromJson(needs.test_tf_feature.outputs.tf_outputs).random_pet }}"
 
+  test_tf_cleanup:
+    needs: [test_tf_feature, test_tf_outputs, test_tf_outputs_decode_random_pet]
+    uses: ./.github/workflows/tf-cleanup.yaml
+    with:
+      environment: sandbox
+      tf_workspace: test/slash/replacement
+
+  test_tf_feature_no_environment:
+    uses: ./.github/workflows/tf-feature.yaml
+    with:
+      aws_oidc_role_arn: arn:aws:iam::911453050078:role/cicd-iac
+      aws_region: eu-central-1
+      tf_dir: tests/terraform/s3
+      tf_workspace: feature-no-environment
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=test-tf-feature-no-environment.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
+
+  test_tf_cleanup_no_environment:
+    needs: test_tf_feature_no_environment
+    uses: ./.github/workflows/tf-cleanup.yaml
+    with:
+      aws_oidc_role_arn: arn:aws:iam::911453050078:role/cicd-iac
+      aws_region: eu-central-1
+      tf_dir: tests/terraform/s3
+      tf_workspace: feature-no-environment
+      tf_backend_configs: |
+        bucket=tf-state-911453050078
+        key=test-tf-feature-no-environment.tfstate
+        workspace_key_prefix=github-workflows
+      tf_var_files: tests/terraform/s3/environment/sandbox.tfvars
+
   test_tf_plan:
     uses: ./.github/workflows/tf-plan.yaml
     with:
@@ -38,13 +72,6 @@ jobs:
     with:
       environment: sandbox
       tf_pre_run: curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip -qq awscliv2.zip && ./aws/install
-
-  test_tf_cleanup:
-    needs: test_tf_apply
-    uses: ./.github/workflows/tf-cleanup.yaml
-    with:
-      environment: sandbox
-      tf_workspace: test/slash/replacement
 
   test_tf_plan_no_environment:
     uses: ./.github/workflows/tf-plan.yaml

--- a/.github/workflows/tf-cleanup.yaml
+++ b/.github/workflows/tf-cleanup.yaml
@@ -84,7 +84,6 @@ jobs:
       - name: Terraform Destroy
         uses: dflook/terraform-destroy-workspace@d325c330b1a2cb66e2f873a8438bdd82f3914099 # v1
         id: first_try
-        continue-on-error: true
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
@@ -103,7 +102,7 @@ jobs:
 
       - name: Retry Terraform Destroy
         uses: dflook/terraform-destroy-workspace@d325c330b1a2cb66e2f873a8438bdd82f3914099 # v1
-        if: ${{ steps.first_try.outputs.failure-reason == 'destroy-failed' }}
+        if: ${{ failure() && steps.first_try.outputs.failure-reason == 'destroy-failed' }}
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36

--- a/.github/workflows/tf-destroy.yaml
+++ b/.github/workflows/tf-destroy.yaml
@@ -72,7 +72,6 @@ jobs:
       - name: Terraform Destroy
         uses: dflook/terraform-destroy@2e74fdc282c2980b12503986b2d8483d7cbfa14a # v1
         id: first_try
-        continue-on-error: true
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36
@@ -90,6 +89,7 @@ jobs:
 
       - name: Terraform Destroy
         uses: dflook/terraform-destroy@2e74fdc282c2980b12503986b2d8483d7cbfa14a # v1
+        if: ${{ failure() && steps.first_try.outputs.failure-reason == 'destroy-failed' }}
         env:
           TERRAFORM_PRE_RUN: |
             AWS_CLI_VERSION=2.15.36

--- a/tests/terraform/s3/main.tf
+++ b/tests/terraform/s3/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.7"
   backend "s3" {
     dynamodb_table = "terraform-lock"
     region         = "eu-central-1"


### PR DESCRIPTION
## Description
Error on cleanup/destroy workflows if any errors occur 

## Motivation and Context
If TF init failed the cleanup job would silently error and go unnoticed.

## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
