### PR TITLE
doc: document release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,15 @@ Documentation: [GitHub Actions - Documentation GitHub](https://docs.github.com/e
 
 ## Releases
 
-Release pipeline is triggered on each PR merged to main, which creates a new release incrementing automatically minor version.
+Release pipeline is triggered on each PR merged to main. Depending on the commit message (see [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0/)) a new github release will be created.
+
+If the commit message starts with:
+
+- `feat!:`, a new major release will be created
+- `feat:`, a new minor release will be created
+- `fix:`, a new patch release will be created
+
+otherwise no new release will be created.
 
 ## Contributing
 


### PR DESCRIPTION
## Description
Fix documentation on how to releases on this repo

## Motivation and Context
- README was wrong
- Need to release a new minor version because of the addition of the lambda-python workflow

--> When merging this PR, put "feat: Add Lambda-Python workflow" at the start the message

## Breaking Changes
none

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s)
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

