### PR TITLE
Fum 3408 - move some repos between github organization 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ That's it! You have successfully set up and customized a reusable workflow in yo
 
 Generic workflows can be seamlessly deployed to your repository using the [Tam CLI tool](https://github.com/DND-IT/tam-cli).
 This tool simplifies the process by automatically creating a pull request in your repository, ensuring that all required inputs and GitHub environments are generated and configured for you.
-Tam CLI leverages templates defined in the [Templates](https://github.com/tx-pts-dai/templates/tree/main/addons/github-workflows) repository.
+Tam CLI leverages templates defined in the [Templates](https://github.com/DND-IT/templates/tree/main/addons/github-workflows) repository.
 For more details refer to the [Tam CLI](docs/getting-started/tam-cli.md) page.
 
 <!--usage-end-->

--- a/docs/getting-started/tam-cli.md
+++ b/docs/getting-started/tam-cli.md
@@ -4,12 +4,12 @@ Generic workflows can be deployed to your repository using the Tam CLI tool. Thi
 
 **Note**: Tam CLI is a tool designed to deploy various types of templates. The template for workflows can be selected during tool execution by choosing the option: _Addons/GithubWorkflows_
 
-```
+```sh
 tam template init your-destination-repository
 
 Enter team/account to include configurations (20minuten, dai, disco, discovery,
 ness, pmd, sfmc, test, titan, unity): select the team/account
-Enter the template to use [tx-pts-dai/templates]:
+Enter the template to use [DND-IT/templates]:
 You've downloaded .cookiecutters/templates before.
 Is it okay to delete and re-download it? [y/n] (y): y
 Select a template


### PR DESCRIPTION
## Description

Update the references to github repos which have changed

## Motivation and Context

From [FUM-3408](https://tamedia.atlassian.net/browse/FUM-3408), two template repositories are in the process of being transferred from the [tx-pts-dai](https://github.com/tx-pts-dai) to the [DND-IT](https://github.com/DND-IT) organization. This PR align the tam-cli defaults and documentation with those new references

## Breaking Changes

nonw

## How Has This Been Tested?
- [🚫  ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s) --> Not applicable
- [✅ ] I have executed `pre-commit run -a` on my pull request
- [✅ ] I have executed `make gen_docs_run` on my pull request --> but it's not working (gen-doc not found)
