### PR TITLE
doc: update header indentation

### DIFF
--- a/docs/.scripts/gen_docs/bin/index.js
+++ b/docs/.scripts/gen_docs/bin/index.js
@@ -10,7 +10,7 @@ const staticWorkflowsPath = '.github/workflows';
 const outputDir = path.resolve('docs', 'workflows');
 const githubOrg = 'tx-pts-dai';
 const githubRepo = 'github-workflows';
-const currentMajorVersion = 'v1';
+const currentMajorVersion = 'v2';
 
 // Ensure the output directory exists
 if (!fs.existsSync(outputDir)) {
@@ -23,8 +23,6 @@ function generateMarkdownContent(workflowName, workflowFilePath) {
 title: ${workflowName}
 ---
 
-<!-- action-docs-header source="${workflowFilePath}" -->
-
 ## Description
 
 <!-- action-docs-inputs source="${workflowFilePath}" -->
@@ -33,9 +31,9 @@ title: ${workflowName}
 
 <!-- action-docs-usage source="${workflowFilePath}" project="${githubOrg}/${githubRepo}/${workflowFilePath}" version="${currentMajorVersion}" -->
 
-# Example
+## Example
 
-# FAQ
+## FAQ
 `;
 }
 
@@ -84,7 +82,7 @@ async function generateDocs() {
         console.log(`Generating action documentation for ${file}`);
         await generateActionMarkdownDocs({
           sourceFile: workflowFilePath,
-          tocLevel: 1,
+          tocLevel: 2,
           updateReadme: true,
           readmeFile: outputFilePath,
           includeNameHeader: true,

--- a/docs/workflows/aws-secrets-copy.md
+++ b/docs/workflows/aws-secrets-copy.md
@@ -3,7 +3,7 @@ title: AWS Secrets Copy
 ---
 
 <!-- action-docs-header source=".github/workflows/aws-secrets-copy.yaml" -->
-# AWS Secrets Copy
+## AWS Secrets Copy
 <!-- action-docs-header source=".github/workflows/aws-secrets-copy.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: AWS Secrets Copy
 This workflow copies an AWS secret from one account to another.
 
 <!-- action-docs-inputs source=".github/workflows/aws-secrets-copy.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -29,13 +29,13 @@ This workflow copies an AWS secret from one account to another.
 
 <!-- action-docs-outputs source=".github/workflows/aws-secrets-copy.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/aws-secrets-copy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/aws-secrets-copy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml@v2
     with:
       source_aws_region:
       # AWS region
@@ -93,11 +93,9 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/aws-secrets-copy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/aws-secrets-copy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/aws-secrets-copy.yaml" version="v2" -->
 
-
-
-## Examples
+## Example
 
 ```yaml
 on: [push, pull_request]
@@ -112,7 +110,7 @@ jobs:
       destination_aws_oidc_role_arn: 'arn:aws:iam::012345678901:role/my-aws-role'
 ```
 
-## FAQs
+## FAQ
 
 **Q: What happen if the destination secret already exists ?**
 

--- a/docs/workflows/docker-build-push-ecr.md
+++ b/docs/workflows/docker-build-push-ecr.md
@@ -3,7 +3,7 @@ title: Docker Build and Push to ECR
 ---
 
 <!-- action-docs-header source=".github/workflows/docker-build-push-ecr.yaml" -->
-# Docker Build and Push to ECR
+## Docker Build and Push to ECR
 <!-- action-docs-header source=".github/workflows/docker-build-push-ecr.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Docker Build and Push to ECR
 This workflow builds a Docker image and pushes it to the Elastic Container Registry (ECR).
 
 <!-- action-docs-inputs source=".github/workflows/docker-build-push-ecr.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -36,13 +36,13 @@ This workflow builds a Docker image and pushes it to the Elastic Container Regis
 
 <!-- action-docs-outputs source=".github/workflows/docker-build-push-ecr.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/docker-build-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/docker-build-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml@v2
     with:
       environment:
       # Environment to run the build in
@@ -149,9 +149,9 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/docker-build-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/docker-build-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build-push-ecr.yaml" version="v2" -->
 
-## Examples
+## Example
 
 ```yaml
 on: [push, pull_request]
@@ -169,7 +169,7 @@ jobs:
       docker_push: 'true'
 ```
 
-## FAQs
+## FAQ
 
 **Q: How do I specify the AWS credentials?**
 

--- a/docs/workflows/docker-build.md
+++ b/docs/workflows/docker-build.md
@@ -3,7 +3,7 @@ title: Docker Build
 ---
 
 <!-- action-docs-header source=".github/workflows/docker-build.yaml" -->
-# Docker Build
+## Docker Build
 <!-- action-docs-header source=".github/workflows/docker-build.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Docker Build
 This workflow builds a Docker image and the artifact is uploaded to the GitHub artifact store.
 
 <!-- action-docs-inputs source=".github/workflows/docker-build.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -26,13 +26,13 @@ This workflow builds a Docker image and the artifact is uploaded to the GitHub a
 
 <!-- action-docs-outputs source=".github/workflows/docker-build.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/docker-build.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/docker-build.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml@v2
     with:
       environment:
       # Environment to deploy
@@ -69,7 +69,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/docker-build.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/docker-build.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-build.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/docker-push-ecr.md
+++ b/docs/workflows/docker-push-ecr.md
@@ -3,7 +3,7 @@ title: Docker Push to ECR
 ---
 
 <!-- action-docs-header source=".github/workflows/docker-push-ecr.yaml" -->
-# Docker Push to ECR
+## Docker Push to ECR
 <!-- action-docs-header source=".github/workflows/docker-push-ecr.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Docker Push to ECR
 This workflow pushes a Docker artifact to an ECR repository.
 
 <!-- action-docs-inputs source=".github/workflows/docker-push-ecr.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -28,13 +28,13 @@ This workflow pushes a Docker artifact to an ECR repository.
 
 <!-- action-docs-outputs source=".github/workflows/docker-push-ecr.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/docker-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/docker-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml@v2
     with:
       environment:
       # Environment to deploy
@@ -85,7 +85,7 @@ jobs:
       # Required: false
       # Default: ${{ github.sha }}
 ```
-<!-- action-docs-usage source=".github/workflows/docker-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/docker-push-ecr.yaml" project="tx-pts-dai/github-workflows/.github/workflows/docker-push-ecr.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/gh-release-on-main.md
+++ b/docs/workflows/gh-release-on-main.md
@@ -3,7 +3,7 @@ title: Github Conventional Commit Release
 ---
 
 <!-- action-docs-header source=".github/workflows/gh-release-on-main.yaml" -->
-# Github Conventional Commit Release
+## Github Conventional Commit Release
 <!-- action-docs-header source=".github/workflows/gh-release-on-main.yaml" -->
 
 ## Description
@@ -17,11 +17,11 @@ The release automatically increases the patch, minor or major version, but also 
 The workflow pays attention to the title of the latest commit and check what it starts with. Which means that when squashing and merging your PR, you need to add the proper key words.
 
 The options are:
+
 1. "fix: Some comment" -> will increment the patch version x.x.PATCH+1
 2. "feat: Some comment" -> will increment the minor version x.MINOR+1.0
 3. "feat!: Some comment" -> will increment the major version MAJOR+1.0.0
 
-
 <!-- action-docs-inputs source=".github/workflows/gh-release-on-main.yaml" -->
 
 <!-- action-docs-inputs source=".github/workflows/gh-release-on-main.yaml" -->
@@ -30,23 +30,23 @@ The options are:
 
 <!-- action-docs-outputs source=".github/workflows/gh-release-on-main.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/gh-release-on-main.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/gh-release-on-main.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml@v2
 ```
-<!-- action-docs-usage source=".github/workflows/gh-release-on-main.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/gh-release-on-main.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release-on-main.yaml" version="v2" -->
 
-## Examples
+## Example
 
 - we currently are at version v1.1.1. . Squashing/merging a PR with a "fix:" prefix will increase the patch version (-> v1.1.2), and also will renew tagging so that workflows already calling @v1 or @v1.1 would target the new release v1.1.2.
 
 - we currently are at version v1.1.9. Squashing/merging a PR with a "feat:" prefix will increase the minor version (-> v1.2.0), and also will renew tagging so that workflows already calling @v1 or @v1.2 would target the new release v1.2.0.
 
-## FAQs
+## FAQ
 
 **Q: How is the version number determined?**
 

--- a/docs/workflows/gh-release.md
+++ b/docs/workflows/gh-release.md
@@ -3,7 +3,7 @@ title: Github Release
 ---
 
 <!-- action-docs-header source=".github/workflows/gh-release.yaml" -->
-# Github Release
+## Github Release
 <!-- action-docs-header source=".github/workflows/gh-release.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Github Release
 This workflow creates a release based on the tag.
 
 <!-- action-docs-inputs source=".github/workflows/gh-release.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -22,13 +22,13 @@ This workflow creates a release based on the tag.
 
 <!-- action-docs-outputs source=".github/workflows/gh-release.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/gh-release.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/gh-release.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml@v2
     with:
       tag:
       # The tag to release
@@ -37,7 +37,7 @@ jobs:
       # Required: true
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/gh-release.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/gh-release.yaml" project="tx-pts-dai/github-workflows/.github/workflows/gh-release.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/lambda-build-node.md
+++ b/docs/workflows/lambda-build-node.md
@@ -3,7 +3,7 @@ title: Build Lambda Layer
 ---
 
 <!-- action-docs-header source=".github/workflows/lambda-build-node.yaml" -->
-# Build Lambda Layer
+## Build Lambda Layer
 <!-- action-docs-header source=".github/workflows/lambda-build-node.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Build Lambda Layer
 This workflow builds a Lambda Layer and the artifact is uploaded to the GitHub artifact store.
 
 <!-- action-docs-inputs source=".github/workflows/lambda-build-node.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -26,13 +26,13 @@ This workflow builds a Lambda Layer and the artifact is uploaded to the GitHub a
 
 <!-- action-docs-outputs source=".github/workflows/lambda-build-node.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/lambda-build-node.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/lambda-build-node.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml@v2
     with:
       environment:
       # Environment to deploy.
@@ -69,9 +69,9 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/lambda-build-node.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/lambda-build-node.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-build-node.yaml" version="v2" -->
 
-## Examples
+## Example
 
 ```yaml
 on: [push, pull_request]
@@ -85,7 +85,7 @@ jobs:
       artifact_retention_days: 5
 ```
 
-## FAQs
+## FAQ
 
 **Q: How do I specify the Node.js version?**
 

--- a/docs/workflows/lambda-nodejs.md
+++ b/docs/workflows/lambda-nodejs.md
@@ -3,7 +3,7 @@ title: Build NodeJS Lambda
 ---
 
 <!-- action-docs-header source=".github/workflows/lambda-nodejs.yaml" -->
-# Build NodeJS Lambda
+## Build NodeJS Lambda
 <!-- action-docs-header source=".github/workflows/lambda-nodejs.yaml" -->
 
 ## Description
@@ -13,7 +13,7 @@ Simple workflow to build a NodeJS Lambda function and upload the artifact to the
 All packages defined in the `package.json` file will be installed and packaged into a zip file.
 
 <!-- action-docs-inputs source=".github/workflows/lambda-nodejs.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -28,13 +28,13 @@ All packages defined in the `package.json` file will be installed and packaged i
 
 <!-- action-docs-outputs source=".github/workflows/lambda-nodejs.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/lambda-nodejs.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/lambda-nodejs.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml@v2
     with:
       node_version:
       # NodeJS version
@@ -71,11 +71,11 @@ jobs:
       # Required: false
       # Default: 30
 ```
-<!-- action-docs-usage source=".github/workflows/lambda-nodejs.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/lambda-nodejs.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-nodejs.yaml" version="v2" -->
 
-# Example
+## Example
 
-```
+```yaml
 name: Build
 
 on:
@@ -92,4 +92,4 @@ jobs:
       source_dir: src/lambda
 ```
 
-# FAQ
+## FAQ

--- a/docs/workflows/lambda-python.md
+++ b/docs/workflows/lambda-python.md
@@ -1,5 +1,9 @@
+---
+title: Build Python Lambda
+---
+
 <!-- action-docs-header source=".github/workflows/lambda-python.yaml" -->
-# Build Python Lambda
+## Build Python Lambda
 <!-- action-docs-header source=".github/workflows/lambda-python.yaml" -->
 
 ## Description
@@ -10,7 +14,7 @@ The zip file will be saved as a github artifact.
 Usefull to deploy an AWS lambda function or layer.
 
 <!-- action-docs-inputs source=".github/workflows/lambda-python.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -25,13 +29,13 @@ Usefull to deploy an AWS lambda function or layer.
 
 <!-- action-docs-outputs source=".github/workflows/lambda-python.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/lambda-python.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/lambda-python.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml@v2
     with:
       python_version:
       # Python version. Check https://github.com/actions/setup-python for valid values
@@ -68,7 +72,7 @@ jobs:
       # Required: false
       # Default: 30
 ```
-<!-- action-docs-usage source=".github/workflows/lambda-python.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/lambda-python.yaml" project="tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml" version="v2" -->
 
 ## Example
 
@@ -83,7 +87,7 @@ on:
 
 jobs:
   build:
-    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/lambda-python.yaml@v2
     with:
       python_version: "3.12"
       source_dir: lambdas/first_lambda

--- a/docs/workflows/tf-apply.md
+++ b/docs/workflows/tf-apply.md
@@ -3,7 +3,7 @@ title: Terraform Apply
 ---
 
 <!-- action-docs-header source=".github/workflows/tf-apply.yaml" -->
-# Terraform Apply
+## Terraform Apply
 <!-- action-docs-header source=".github/workflows/tf-apply.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Terraform Apply
 This workflow applies the Terraform configuration.
 
 <!-- action-docs-inputs source=".github/workflows/tf-apply.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -34,20 +34,20 @@ This workflow applies the Terraform configuration.
 <!-- action-docs-inputs source=".github/workflows/tf-apply.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-apply.yaml" -->
-## Outputs
+### Outputs
 
 | name | description |
 | --- | --- |
 | `tf_outputs` | <p>List of Terraform outputs captured.</p> |
 <!-- action-docs-outputs source=".github/workflows/tf-apply.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/tf-apply.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/tf-apply.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml@v2
     with:
       environment:
       # Environment to deploy.
@@ -161,7 +161,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/tf-apply.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/tf-apply.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-apply.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/tf-cleanup.md
+++ b/docs/workflows/tf-cleanup.md
@@ -3,7 +3,7 @@ title: Terraform Preview Cleanup
 ---
 
 <!-- action-docs-header source=".github/workflows/tf-cleanup.yaml" -->
-# Terraform Preview Cleanup
+## Terraform Preview Cleanup
 <!-- action-docs-header source=".github/workflows/tf-cleanup.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Terraform Preview Cleanup
 This workflow cleans up the Terraform preview deployments.
 
 <!-- action-docs-inputs source=".github/workflows/tf-cleanup.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -34,13 +34,13 @@ This workflow cleans up the Terraform preview deployments.
 
 <!-- action-docs-outputs source=".github/workflows/tf-cleanup.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/tf-cleanup.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/tf-cleanup.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml@v2
     with:
       environment:
       # Environment to deploy
@@ -133,7 +133,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/tf-cleanup.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/tf-cleanup.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-cleanup.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/tf-destroy.md
+++ b/docs/workflows/tf-destroy.md
@@ -3,7 +3,7 @@ title: Terraform Destroy
 ---
 
 <!-- action-docs-header source=".github/workflows/tf-destroy.yaml" -->
-# Terraform Destroy
+## Terraform Destroy
 <!-- action-docs-header source=".github/workflows/tf-destroy.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Terraform Destroy
 This workflow destroys Terraform resources.
 
 <!-- action-docs-inputs source=".github/workflows/tf-destroy.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -33,13 +33,13 @@ This workflow destroys Terraform resources.
 
 <!-- action-docs-outputs source=".github/workflows/tf-destroy.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/tf-destroy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/tf-destroy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml@v2
     with:
       environment:
       # Environment to deploy.
@@ -125,7 +125,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/tf-destroy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/tf-destroy.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-destroy.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/tf-feature.md
+++ b/docs/workflows/tf-feature.md
@@ -3,7 +3,7 @@ title: Terraform Preview Deployment
 ---
 
 <!-- action-docs-header source=".github/workflows/tf-feature.yaml" -->
-# Terraform Preview Deployment
+## Terraform Preview Deployment
 <!-- action-docs-header source=".github/workflows/tf-feature.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Terraform Preview Deployment
 This workflow deploys a Terraform configuration to a preview environment.
 
 <!-- action-docs-inputs source=".github/workflows/tf-feature.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -34,20 +34,20 @@ This workflow deploys a Terraform configuration to a preview environment.
 <!-- action-docs-inputs source=".github/workflows/tf-feature.yaml" -->
 
 <!-- action-docs-outputs source=".github/workflows/tf-feature.yaml" -->
-## Outputs
+### Outputs
 
 | name | description |
 | --- | --- |
 | `tf_outputs` | <p>List of Terraform outputs captured.</p> |
 <!-- action-docs-outputs source=".github/workflows/tf-feature.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/tf-feature.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/tf-feature.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml@v2
     with:
       environment:
       # Environment to deploy
@@ -161,7 +161,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/tf-feature.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/tf-feature.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-feature.yaml" version="v2" -->
 
 # Example
 

--- a/docs/workflows/tf-plan.md
+++ b/docs/workflows/tf-plan.md
@@ -3,7 +3,7 @@ title: Terraform Plan
 ---
 
 <!-- action-docs-header source=".github/workflows/tf-plan.yaml" -->
-# Terraform Plan
+## Terraform Plan
 <!-- action-docs-header source=".github/workflows/tf-plan.yaml" -->
 
 ## Description
@@ -11,7 +11,7 @@ title: Terraform Plan
 This workflow runs `terraform plan` and uploads the plan to Github Action summary and creates a PR comment.
 
 <!-- action-docs-inputs source=".github/workflows/tf-plan.yaml" -->
-## Inputs
+### Inputs
 
 | name | description | type | required | default |
 | --- | --- | --- | --- | --- |
@@ -38,13 +38,13 @@ This workflow runs `terraform plan` and uploads the plan to Github Action summar
 
 <!-- action-docs-outputs source=".github/workflows/tf-plan.yaml" -->
 
-<!-- action-docs-usage source=".github/workflows/tf-plan.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml" version="v1" -->
-## Usage
+<!-- action-docs-usage source=".github/workflows/tf-plan.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml" version="v2" -->
+### Usage
 
 ```yaml
 jobs:
   job1:
-    uses: tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml@v1
+    uses: tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml@v2
     with:
       environment:
       # Environment to deploy.
@@ -165,7 +165,7 @@ jobs:
       # Required: false
       # Default: ""
 ```
-<!-- action-docs-usage source=".github/workflows/tf-plan.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml" version="v1" -->
+<!-- action-docs-usage source=".github/workflows/tf-plan.yaml" project="tx-pts-dai/github-workflows/.github/workflows/tf-plan.yaml" version="v2" -->
 
 # Example
 


### PR DESCRIPTION
## Description

Update the doc with last major release of the repo (v2 instead of v1)

## Motivation and Context

The documentation (see https://tx-pts-dai.github.io/github-workflows/workflows/tf-apply/ for examle) is still referring v1 of the workflow, this PR fix it

And some change to  the indentation of the headers to make markdown linter more happy
(I removed the `action-doc-header` in the template because it's exactly the same as the workflowName in the title)

## Breaking Changes

None, it's only a change in the documentation

## How Has This Been Tested?
- [ ] I have updated at least one of the `.github/workflows/_test-*.yaml` to demonstrate and validate my change(s) --> no need
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have executed `make gen_docs_run` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
